### PR TITLE
v2g: update the usage for the tshark for debug during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 Wireshark's LUA documentation:  https://wiki.wireshark.org/Lua
 
+### Mac OS X
+
+Install wireshark application in the usual location, and this will
+allow access to the tshark application to run the script and debug
+the output.
+
+```
+/Applications/Wireshark.app/Contents/MacOS/tshark \
+    -X lua_script:v2g.lua -r test.pcap
+```
+
 ## Decrypting TLS payloads
 
-This LUA code will automatically decrypt the V2G traffic if a UDP packet is emitted on port 15118 with the TLS key used to ecrypt the session.
+This LUA code will automatically decrypt the V2G traffic if a UDP packet is
+emitted on port 15118 with the TLS key used to ecrypt the session.

--- a/v2g.lua
+++ b/v2g.lua
@@ -72,6 +72,7 @@ function v2gtp_protocol.dissector(buffer, pinfo, tree)
         local bitval = buffer(9,2):bitfield(0, 1)
         subtree:add(exi_suported_app_proto_res, bitval)
         print('bit', bitval)
+   end
 end
 
 function get_sdp_payload_type(type)


### PR DESCRIPTION
Address the error from the tshark output from lua

    $ tshark -X lua_script:v2g.lua
    tshark: Lua: syntax error: v2g.lua:104: 'end' expected
                 (to close 'function' at line 30) near <eof>

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>