### PR TITLE
dissectors: pass the packet info to the body to for info

### DIFF
--- a/src/packet-v2gdin.c
+++ b/src/packet-v2gdin.c
@@ -4203,6 +4203,7 @@ dissect_v2gdin_weldingdetectionres(
 static void
 dissect_v2gdin_body(const struct dinBodyType *body,
 		    tvbuff_t *tvb,
+		    packet_info *pinfo,
 		    proto_tree *tree,
 		    gint idx,
 		    const char *subtree_name)
@@ -4213,12 +4214,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 		tvb, 0, 0, idx, NULL, subtree_name);
 
 	if (body->SessionSetupReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionSetupReq");
 		dissect_v2gdin_sessionsetupreq(
 			&body->SessionSetupReq, tvb, body_tree,
 			ett_v2gdin_struct_dinSessionSetupReqType,
 			"SessionSetupReq");
 	}
 	if (body->SessionSetupRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionSetupRes");
 		dissect_v2gdin_sessionsetupres(
 			&body->SessionSetupRes, tvb, body_tree,
 			ett_v2gdin_struct_dinSessionSetupResType,
@@ -4226,12 +4229,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->ServiceDiscoveryReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDiscoveryReq");
 		dissect_v2gdin_servicediscoveryreq(
 			&body->ServiceDiscoveryReq, tvb, body_tree,
 			ett_v2gdin_struct_dinServiceDiscoveryReqType,
 			"ServiceDiscoveryReq");
 	}
 	if (body->ServiceDiscoveryRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDiscoveryRes");
 		dissect_v2gdin_servicediscoveryres(
 			&body->ServiceDiscoveryRes, tvb, body_tree,
 			ett_v2gdin_struct_dinServiceDiscoveryResType,
@@ -4239,12 +4244,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->ServiceDetailReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDetailReq");
 		dissect_v2gdin_servicedetailreq(
 			&body->ServiceDetailReq, tvb, body_tree,
 			ett_v2gdin_struct_dinServiceDetailReqType,
 			"ServiceDetailReq");
 	}
 	if (body->ServiceDetailRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDetailRes");
 		dissect_v2gdin_servicedetailres(
 			&body->ServiceDetailRes, tvb, body_tree,
 			ett_v2gdin_struct_dinServiceDetailResType,
@@ -4252,12 +4259,16 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->ServicePaymentSelectionReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ServicePaymentSelectionReq");
 		dissect_v2gdin_servicepaymentselectionreq(
 			&body->ServicePaymentSelectionReq, tvb, body_tree,
 			ett_v2gdin_struct_dinServicePaymentSelectionReqType,
 			"ServicePaymentSelectionReq");
 	}
 	if (body->ServicePaymentSelectionRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ServicePaymentSelectionRes");
 		dissect_v2gdin_servicepaymentselectionres(
 			&body->ServicePaymentSelectionRes, tvb, body_tree,
 			ett_v2gdin_struct_dinServicePaymentSelectionResType,
@@ -4265,12 +4276,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->PaymentDetailsReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PaymentDetailsReq");
 		dissect_v2gdin_paymentdetailsreq(
 			&body->PaymentDetailsReq, tvb, body_tree,
 			ett_v2gdin_struct_dinPaymentDetailsReqType,
 			"PaymentDetailsReq");
 	}
 	if (body->PaymentDetailsRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PaymentDetailsRes");
 		dissect_v2gdin_paymentdetailsres(
 			&body->PaymentDetailsRes, tvb, body_tree,
 			ett_v2gdin_struct_dinPaymentDetailsResType,
@@ -4278,12 +4291,16 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->ContractAuthenticationReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ContractAuthenticationReq");
 		dissect_v2gdin_contractauthenticationreq(
 			&body->ContractAuthenticationReq, tvb, body_tree,
 			ett_v2gdin_struct_dinContractAuthenticationReqType,
 			"ContractAuthenticationReq");
 	}
 	if (body->ContractAuthenticationRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ContractAuthenticationRes");
 		dissect_v2gdin_contractauthenticationres(
 			&body->ContractAuthenticationRes, tvb, body_tree,
 			ett_v2gdin_struct_dinContractAuthenticationResType,
@@ -4291,12 +4308,16 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->ChargeParameterDiscoveryReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ChargeParameterDiscoveryReq");
 		dissect_v2gdin_chargeparameterdiscoveryreq(
 			&body->ChargeParameterDiscoveryReq, tvb, body_tree,
 			ett_v2gdin_struct_dinChargeParameterDiscoveryReqType,
 			"ChargeParameterDiscoveryReq");
 	}
 	if (body->ChargeParameterDiscoveryRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ChargeParameterDiscoveryRes");
 		dissect_v2gdin_chargeparameterdiscoveryres(
 			&body->ChargeParameterDiscoveryRes, tvb, body_tree,
 			ett_v2gdin_struct_dinChargeParameterDiscoveryResType,
@@ -4304,12 +4325,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->PowerDeliveryReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PowerDeliveryReq");
 		dissect_v2gdin_powerdeliveryreq(
 			&body->PowerDeliveryReq, tvb, body_tree,
 			ett_v2gdin_struct_dinPowerDeliveryReqType,
 			"PowerDeliveryReq");
 	}
 	if (body->PowerDeliveryRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PowerDeliveryRes");
 		dissect_v2gdin_powerdeliveryres(
 			&body->PowerDeliveryRes, tvb, body_tree,
 			ett_v2gdin_struct_dinPowerDeliveryResType,
@@ -4317,12 +4340,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->ChargingStatusReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ChargingStatusReq");
 		dissect_v2gdin_chargingstatusreq(
 			&body->ChargingStatusReq, tvb, body_tree,
 			ett_v2gdin_struct_dinChargingStatusReqType,
 			"ChargingStatusReq");
 	}
 	if (body->ChargingStatusRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ChargingStatusRes");
 		dissect_v2gdin_chargingstatusres(
 			&body->ChargingStatusRes, tvb, body_tree,
 			ett_v2gdin_struct_dinChargingStatusResType,
@@ -4330,12 +4355,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->MeteringReceiptReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "MeteringReceiptReq");
 		dissect_v2gdin_meteringreceiptreq(
 			&body->MeteringReceiptReq, tvb, body_tree,
 			ett_v2gdin_struct_dinMeteringReceiptReqType,
 			"MeteringReceiptReq");
 	}
 	if (body->MeteringReceiptRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "MeteringReceiptRes");
 		dissect_v2gdin_meteringreceiptres(
 			&body->MeteringReceiptRes, tvb, body_tree,
 			ett_v2gdin_struct_dinMeteringReceiptResType,
@@ -4343,12 +4370,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->SessionStopReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionStopReq");
 		dissect_v2gdin_sessionstop(
 			&body->SessionStopReq, tvb, body_tree,
 			ett_v2gdin_struct_dinSessionStopType,
 			"SessionStopReq");
 	}
 	if (body->SessionStopRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionStopRes");
 		dissect_v2gdin_sessionstopres(
 			&body->SessionStopRes, tvb, body_tree,
 			ett_v2gdin_struct_dinSessionStopResType,
@@ -4356,12 +4385,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->CertificateUpdateReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CertificateUpdateReq");
 		dissect_v2gdin_certificateupdatereq(
 			&body->CertificateUpdateReq, tvb, body_tree,
 			ett_v2gdin_struct_dinCertificateUpdateReqType,
 			"CertificateUpdateReq");
 	}
 	if (body->CertificateUpdateRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CertificateUpdateRes");
 		dissect_v2gdin_certificateupdateres(
 			&body->CertificateUpdateRes, tvb, body_tree,
 			ett_v2gdin_struct_dinCertificateUpdateResType,
@@ -4369,12 +4400,16 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->CertificateInstallationReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"CertificateInstallationReq");
 		dissect_v2gdin_certificateinstallationreq(
 			&body->CertificateInstallationReq, tvb, body_tree,
 			ett_v2gdin_struct_dinCertificateInstallationReqType,
 			"CertificateInstallationReq");
 	}
 	if (body->CertificateInstallationRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"CertificateInstallationRes");
 		dissect_v2gdin_certificateinstallationres(
 			&body->CertificateInstallationRes, tvb, body_tree,
 			ett_v2gdin_struct_dinCertificateInstallationResType,
@@ -4382,12 +4417,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->CableCheckReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CableCheckReq");
 		dissect_v2gdin_cablecheckreq(
 			&body->CableCheckReq, tvb, body_tree,
 			ett_v2gdin_struct_dinCableCheckReqType,
 			"CableCheckReq");
 	}
 	if (body->CableCheckRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CableCheckRes");
 		dissect_v2gdin_cablecheckres(
 			&body->CableCheckRes, tvb, body_tree,
 			ett_v2gdin_struct_dinCableCheckResType,
@@ -4395,12 +4432,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->PreChargeReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PreChargeReq");
 		dissect_v2gdin_prechargereq(
 			&body->PreChargeReq, tvb, body_tree,
 			ett_v2gdin_struct_dinPreChargeReqType,
 			"PreChargeReq");
 	}
 	if (body->PreChargeRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PreChargeRes");
 		dissect_v2gdin_prechargeres(
 			&body->PreChargeRes, tvb, body_tree,
 			ett_v2gdin_struct_dinPreChargeResType,
@@ -4408,12 +4447,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->CurrentDemandReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CurrentDemandReq");
 		dissect_v2gdin_currentdemandreq(
 			&body->CurrentDemandReq, tvb, body_tree,
 			ett_v2gdin_struct_dinCurrentDemandReqType,
 			"CurrentDemandReq");
 	}
 	if (body->CurrentDemandRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CurrentDemandRes");
 		dissect_v2gdin_currentdemandres(
 			&body->CurrentDemandRes, tvb, body_tree,
 			ett_v2gdin_struct_dinCurrentDemandResType,
@@ -4421,12 +4462,14 @@ dissect_v2gdin_body(const struct dinBodyType *body,
 	}
 
 	if (body->WeldingDetectionReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "WeldingDetectionReq");
 		dissect_v2gdin_weldingdetectionreq(
 			&body->WeldingDetectionReq, tvb, body_tree,
 			ett_v2gdin_struct_dinWeldingDetectionReqType,
 			"WeldingDetectionReq");
 	}
 	if (body->WeldingDetectionRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "WeldingDetectionRes");
 		dissect_v2gdin_weldingdetectionres(
 			&body->WeldingDetectionRes, tvb, body_tree,
 			ett_v2gdin_struct_dinWeldingDetectionResType,
@@ -4473,7 +4516,7 @@ dissect_v2gdin(tvbuff_t *tvb,
 		dissect_v2gdin_header(&exidin.V2G_Message.Header,
 			tvb, v2gdin_tree, ett_v2gdin_header, "Header");
 		dissect_v2gdin_body(&exidin.V2G_Message.Body,
-			tvb, v2gdin_tree, ett_v2gdin_body, "Body");
+			tvb, pinfo, v2gdin_tree, ett_v2gdin_body, "Body");
 	}
 
 	return tvb_captured_length(tvb);

--- a/src/packet-v2giso1.c
+++ b/src/packet-v2giso1.c
@@ -4367,6 +4367,7 @@ dissect_v2giso1_weldingdetectionres(
 static void
 dissect_v2giso1_body(const struct iso1BodyType *body,
 		     tvbuff_t *tvb,
+		     packet_info *pinfo,
 		     proto_tree *tree,
 		     gint idx,
 		     const char *subtree_name)
@@ -4377,12 +4378,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 		tvb, 0, 0, idx, NULL, subtree_name);
 
 	if (body->SessionSetupReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionSetupReq");
 		dissect_v2giso1_sessionsetupreq(
 			&body->SessionSetupReq, tvb, subtree,
 			ett_v2giso1_struct_iso1SessionSetupReqType,
 			"SessionSetupReq");
 	}
 	if (body->SessionSetupRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionSetupRes");
 		dissect_v2giso1_sessionsetupres(
 			&body->SessionSetupRes, tvb, subtree,
 			ett_v2giso1_struct_iso1SessionSetupResType,
@@ -4390,12 +4393,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->ServiceDiscoveryReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDiscoveryReq");
 		dissect_v2giso1_servicediscoveryreq(
 			&body->ServiceDiscoveryReq, tvb, subtree,
 			ett_v2giso1_struct_iso1ServiceDiscoveryReqType,
 			"ServiceDiscoveryReq");
 	}
 	if (body->ServiceDiscoveryRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDiscoveryRes");
 		dissect_v2giso1_servicediscoveryres(
 			&body->ServiceDiscoveryRes, tvb, subtree,
 			ett_v2giso1_struct_iso1ServiceDiscoveryResType,
@@ -4403,12 +4408,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->ServiceDetailReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDetailReq");
 		dissect_v2giso1_servicedetailreq(
 			&body->ServiceDetailReq, tvb, subtree,
 			ett_v2giso1_struct_iso1ServiceDetailReqType,
 			"ServiceDetailReq");
 	}
 	if (body->ServiceDetailRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ServiceDetailRes");
 		dissect_v2giso1_servicedetailres(
 			&body->ServiceDetailRes, tvb, subtree,
 			ett_v2giso1_struct_iso1ServiceDetailResType,
@@ -4416,12 +4423,16 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->PaymentServiceSelectionReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"PaymentServiceSelectionReq");
 		dissect_v2giso1_paymentserviceselectionreq(
 			&body->PaymentServiceSelectionReq, tvb, subtree,
 			ett_v2giso1_struct_iso1PaymentServiceSelectionReqType,
 			"PaymentServiceSelectionReq");
 	}
 	if (body->PaymentServiceSelectionRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"PaymentServiceSelectionRes");
 		dissect_v2giso1_paymentserviceselectionres(
 			&body->PaymentServiceSelectionRes, tvb, subtree,
 			ett_v2giso1_struct_iso1PaymentServiceSelectionResType,
@@ -4429,12 +4440,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->PaymentDetailsReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PaymentDetailsReq");
 		dissect_v2giso1_paymentdetailsreq(
 			&body->PaymentDetailsReq, tvb, subtree,
 			ett_v2giso1_struct_iso1PaymentDetailsReqType,
 			"PaymentDetailsReq");
 	}
 	if (body->PaymentDetailsRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PaymentDetailsRes");
 		dissect_v2giso1_paymentdetailsres(
 			&body->PaymentDetailsRes, tvb, subtree,
 			ett_v2giso1_struct_iso1PaymentDetailsResType,
@@ -4442,12 +4455,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->AuthorizationReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "AuthorizationReq");
 		dissect_v2giso1_authorizationreq(
 			&body->AuthorizationReq, tvb, subtree,
 			ett_v2giso1_struct_iso1AuthorizationReqType,
 			"AuthorizationReq");
 	}
 	if (body->AuthorizationRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "AuthorizationRes");
 		dissect_v2giso1_authorizationres(
 			&body->AuthorizationRes, tvb, subtree,
 			ett_v2giso1_struct_iso1AuthorizationResType,
@@ -4455,12 +4470,16 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->ChargeParameterDiscoveryReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ChargeParameterDiscoveryReq");
 		dissect_v2giso1_chargeparameterdiscoveryreq(
 			&body->ChargeParameterDiscoveryReq, tvb, subtree,
 			ett_v2giso1_struct_iso1ChargeParameterDiscoveryReqType,
 			"ChargeParameterDiscoveryReq");
 	}
 	if (body->ChargeParameterDiscoveryRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"ChargeParameterDiscoveryRes");
 		dissect_v2giso1_chargeparameterdiscoveryres(
 			&body->ChargeParameterDiscoveryRes, tvb, subtree,
 			ett_v2giso1_struct_iso1ChargeParameterDiscoveryResType,
@@ -4468,12 +4487,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->PowerDeliveryReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PowerDeliveryReq");
 		dissect_v2giso1_powerdeliveryreq(
 			&body->PowerDeliveryReq, tvb, subtree,
 			ett_v2giso1_struct_iso1PowerDeliveryReqType,
 			"PowerDeliveryReq");
 	}
 	if (body->PowerDeliveryRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PowerDeliveryRes");
 		dissect_v2giso1_powerdeliveryres(
 			&body->PowerDeliveryRes, tvb, subtree,
 			ett_v2giso1_struct_iso1PowerDeliveryResType,
@@ -4481,12 +4502,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->MeteringReceiptReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "MeteringReceiptReq");
 		dissect_v2giso1_meteringreceiptreq(
 			&body->MeteringReceiptReq, tvb, subtree,
 			ett_v2giso1_struct_iso1MeteringReceiptReqType,
 			"MeteringReceiptReq");
 	}
 	if (body->MeteringReceiptRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "MeteringReceiptRes");
 		dissect_v2giso1_meteringreceiptres(
 			&body->MeteringReceiptRes, tvb, subtree,
 			ett_v2giso1_struct_iso1MeteringReceiptResType,
@@ -4494,12 +4517,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->SessionStopReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionStopReq");
 		dissect_v2giso1_sessionstopreq(
 			&body->SessionStopReq, tvb, subtree,
 			ett_v2giso1_struct_iso1SessionStopReqType,
 			"SessionStopReq");
 	}
 	if (body->SessionStopRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "SessionStopRes");
 		dissect_v2giso1_sessionstopres(
 			&body->SessionStopRes, tvb, subtree,
 			ett_v2giso1_struct_iso1SessionStopResType,
@@ -4507,12 +4532,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->CertificateUpdateReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CertificateUpdateReq");
 		dissect_v2giso1_certificateupdatereq(
 			&body->CertificateUpdateReq, tvb, subtree,
 			ett_v2giso1_struct_iso1CertificateUpdateReqType,
 			"CertificateUpdateReq");
 	}
 	if (body->CertificateUpdateRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CertificateUpdateRes");
 		dissect_v2giso1_certificateupdateres(
 			&body->CertificateUpdateRes, tvb, subtree,
 			ett_v2giso1_struct_iso1CertificateUpdateResType,
@@ -4520,12 +4547,16 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->CertificateInstallationReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"CertificateInstallationReq");
 		dissect_v2giso1_certificateinstallationreq(
 			&body->CertificateInstallationReq, tvb, subtree,
 			ett_v2giso1_struct_iso1CertificateInstallationReqType,
 			"CertificateInstallationReq");
 	}
 	if (body->CertificateInstallationRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO,
+			"CertificateInstallationRes");
 		dissect_v2giso1_certificateinstallationres(
 			&body->CertificateInstallationRes, tvb, subtree,
 			ett_v2giso1_struct_iso1CertificateInstallationResType,
@@ -4533,12 +4564,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->ChargingStatusReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ChargingStatusReq");
 		dissect_v2giso1_chargingstatusreq(
 			&body->ChargingStatusReq, tvb, subtree,
 			ett_v2giso1_struct_iso1ChargingStatusReqType,
 			"ChargingStatusReq");
 	}
 	if (body->ChargingStatusRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "ChargingStatusRes");
 		dissect_v2giso1_chargingstatusres(
 			&body->ChargingStatusRes, tvb, subtree,
 			ett_v2giso1_struct_iso1ChargingStatusResType,
@@ -4546,12 +4579,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->CableCheckReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CableCheckReq");
 		dissect_v2giso1_cablecheckreq(
 			&body->CableCheckReq, tvb, subtree,
 			ett_v2giso1_struct_iso1CableCheckReqType,
 			"CableCheckReq");
 	}
 	if (body->CableCheckRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CableCheckRes");
 		dissect_v2giso1_cablecheckres(
 			&body->CableCheckRes, tvb, subtree,
 			ett_v2giso1_struct_iso1CableCheckResType,
@@ -4559,12 +4594,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->PreChargeReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PreChargeReq");
 		dissect_v2giso1_prechargereq(
 			&body->PreChargeReq, tvb, subtree,
 			ett_v2giso1_struct_iso1PreChargeReqType,
 			"PreChargeReq");
 	}
 	if (body->PreChargeRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "PreChargeRes");
 		dissect_v2giso1_prechargeres(
 			&body->PreChargeRes, tvb, subtree,
 			ett_v2giso1_struct_iso1PreChargeResType,
@@ -4572,12 +4609,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->CurrentDemandReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CurrentDemandReq");
 		dissect_v2giso1_currentdemandreq(
 			&body->CurrentDemandReq, tvb, subtree,
 			ett_v2giso1_struct_iso1CurrentDemandReqType,
 			"CurrentDemandReq");
 	}
 	if (body->CurrentDemandRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "CurrentDemandRes");
 		dissect_v2giso1_currentdemandres(
 			&body->CurrentDemandRes, tvb, subtree,
 			ett_v2giso1_struct_iso1CurrentDemandResType,
@@ -4585,12 +4624,14 @@ dissect_v2giso1_body(const struct iso1BodyType *body,
 	}
 
 	if (body->WeldingDetectionReq_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "WeldingDetectionReq");
 		dissect_v2giso1_weldingdetectionreq(
 			&body->WeldingDetectionReq, tvb, subtree,
 			ett_v2giso1_struct_iso1WeldingDetectionReqType,
 			"WeldingDetectionReq");
 	}
 	if (body->WeldingDetectionRes_isUsed) {
+		col_append_str(pinfo->cinfo, COL_INFO, "WeldingDetectionRes");
 		dissect_v2giso1_weldingdetectionres(
 			&body->WeldingDetectionRes, tvb, subtree,
 			ett_v2giso1_struct_iso1WeldingDetectionResType,
@@ -4638,7 +4679,7 @@ dissect_v2giso1(tvbuff_t *tvb,
 		dissect_v2giso1_header(&exiiso1.V2G_Message.Header,
 			tvb, v2giso1_tree, ett_v2giso1_header, "Header");
 		dissect_v2giso1_body(& exiiso1.V2G_Message.Body,
-			tvb, v2giso1_tree, ett_v2giso1_body, "Body");
+			tvb, pinfo, v2giso1_tree, ett_v2giso1_body, "Body");
 	}
 
 	return tvb_captured_length(tvb);

--- a/src/packet-v2giso2.c
+++ b/src/packet-v2giso2.c
@@ -71,6 +71,7 @@ dissect_v2giso2_header(const struct iso2MessageHeaderType *header,
 static void
 dissect_v2giso2_body(const struct iso2BodyType *body,
 		     tvbuff_t *tvb,
+		     packet_info *pinfo,
 		     proto_tree *tree,
 		     gint idx,
 		     const char *subtree_name)
@@ -122,7 +123,7 @@ dissect_v2giso2(tvbuff_t *tvb,
 		dissect_v2giso2_header(&exiiso2.V2G_Message.Header,
 			tvb, v2giso2_tree, ett_v2giso2_header, "Header");
 		dissect_v2giso2_body(& exiiso2.V2G_Message.Body,
-			tvb, v2giso2_tree, ett_v2giso2_body, "Body");
+			tvb, pinfo, v2giso2_tree, ett_v2giso2_body, "Body");
 	}
 
 	return tvb_captured_length(tvb);


### PR DESCRIPTION
The body contains the request/response for the message so pass
the pinfo thru to add the COL_INFO for the struct that is being
used and give some additional context.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>