### PR TITLE
dissector/v2giso1: add in target and present for voltage and current

### DIFF
--- a/src/packet-v2gdin.c
+++ b/src/packet-v2gdin.c
@@ -261,6 +261,11 @@ static int hf_v2gdin_struct_dinCurrentDemandResType_EVSEPowerLimitAchieved = -1;
 
 static int hf_v2gdin_struct_dinWeldingDetectionResType_ResponseCode = -1;
 
+/* Specifically track voltage and current for graphing */
+static int hf_v2gdin_target_voltage = -1;
+static int hf_v2gdin_target_current = -1;
+static int hf_v2gdin_present_voltage = -1;
+static int hf_v2gdin_present_current = -1;
 
 /* Initialize the subtree pointers */
 static gint ett_v2gdin = -1;
@@ -1655,6 +1660,29 @@ dissect_v2gdin_servicetaglist(
 	}
 
 	return;
+}
+
+static inline double
+v2gdin_physicalvalue_to_double(
+	const struct dinPhysicalValueType *physicalvalue)
+{
+	double value;
+	int32_t multiplier;
+
+	value = (double)physicalvalue->Value;
+	multiplier = physicalvalue->Multiplier;
+	if (multiplier > 0) {
+		for (; multiplier != 0; multiplier--) {
+			value *= 10.0;
+		}
+	}
+	if (multiplier < 0) {
+		for (; multiplier != 0; multiplier++) {
+			value /= 10.0;
+		}
+	}
+
+	return value;
 }
 
 static void
@@ -3924,6 +3952,8 @@ dissect_v2gdin_prechargereq(
 	const char *subtree_name)
 {
 	proto_tree *subtree;
+	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -3939,12 +3969,22 @@ dissect_v2gdin_prechargereq(
 		tvb, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVTargetVoltage");
+	value = v2gdin_physicalvalue_to_double(&req->EVTargetVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_target_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2gdin_physicalvalue(
 		&req->EVTargetCurrent,
 		tvb, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVTargetCurrent");
+	value = v2gdin_physicalvalue_to_double(&req->EVTargetCurrent);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_target_current,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	return;
 }
@@ -3959,6 +3999,7 @@ dissect_v2gdin_prechargeres(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -3979,6 +4020,11 @@ dissect_v2gdin_prechargeres(
 		tvb, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVSEPresentVoltage");
+	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_present_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	return;
 }
@@ -3993,6 +4039,7 @@ dissect_v2gdin_currentdemandreq(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4008,12 +4055,22 @@ dissect_v2gdin_currentdemandreq(
 		tvb, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVTargetVoltage");
+	value = v2gdin_physicalvalue_to_double(&req->EVTargetVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_target_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2gdin_physicalvalue(
 		&req->EVTargetCurrent,
 		tvb, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVTargetCurrent");
+	value = v2gdin_physicalvalue_to_double(&req->EVTargetCurrent);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_target_current,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	it = proto_tree_add_int(subtree,
 		hf_v2gdin_struct_dinCurrentDemandReqType_ChargingComplete,
@@ -4080,6 +4137,7 @@ dissect_v2gdin_currentdemandres(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4100,12 +4158,22 @@ dissect_v2gdin_currentdemandres(
 		tvb, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVSEPresentVoltage");
+	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_present_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2gdin_physicalvalue(
 		&res->EVSEPresentCurrent,
 		tvb, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVSEPresentCurrent");
+	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentCurrent);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_present_current,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	it = proto_tree_add_int(subtree,
 		hf_v2gdin_struct_dinCurrentDemandResType_EVSECurrentLimitAchieved,
@@ -4178,6 +4246,7 @@ dissect_v2gdin_weldingdetectionres(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4196,6 +4265,11 @@ dissect_v2gdin_weldingdetectionres(
 		&res->EVSEPresentVoltage,
 		tvb, subtree, ett_v2gdin_struct_dinPhysicalValueType,
 		"EVSEPresentVoltage");
+	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_present_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	return;
 }
@@ -5464,6 +5538,24 @@ proto_register_v2gdin(void)
 		    FT_UINT32, BASE_DEC, VALS(v2gdin_response_code_names),
 		    0x0, NULL, HFILL }
 		},
+
+		/* Derived values for graphing */
+		{ &hf_v2gdin_target_voltage,
+		  { "Voltage", "v2gdin.target.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_target_current,
+		  { "Current", "v2gdin.target.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_present_voltage,
+		  { "Voltage", "v2gdin.present.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_present_current,
+		  { "Current", "v2gdin.present.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		}
 	};
 
 	static gint *ett[] = {

--- a/src/packet-v2giso1.c
+++ b/src/packet-v2giso1.c
@@ -255,6 +255,12 @@ static int hf_v2giso1_struct_iso1CurrentDemandResType_ReceiptRequired = -1;
 
 static int hf_v2giso1_struct_iso1WeldingDetectionResType_ResponseCode = -1;
 
+/* Specifically track voltage and current for graphing */
+static int hf_v2giso1_target_voltage = -1;
+static int hf_v2giso1_target_current = -1;
+static int hf_v2giso1_present_voltage = -1;
+static int hf_v2giso1_present_current = -1;
+
 /* Initialize the subtree pointers */
 static gint ett_v2giso1 = -1;
 static gint ett_v2giso1_header = -1;
@@ -1735,6 +1741,29 @@ dissect_v2giso1_servicelist(
 	}
 
 	return;
+}
+
+static inline double
+v2giso1_physicalvalue_to_double(
+	const struct iso1PhysicalValueType *physicalvalue)
+{
+	double value;
+	int32_t multiplier;
+
+	value = (double)physicalvalue->Value;
+	multiplier = physicalvalue->Multiplier;
+	if (multiplier > 0) {
+		for (; multiplier != 0; multiplier--) {
+			value *= 10.0;
+		}
+	}
+	if (multiplier < 0) {
+		for (; multiplier != 0; multiplier++) {
+			value /= 10.0;
+		}
+	}
+
+	return value;
 }
 
 static void
@@ -4060,6 +4089,8 @@ dissect_v2giso1_prechargereq(
 	const char *subtree_name)
 {
 	proto_tree *subtree;
+	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4075,12 +4106,22 @@ dissect_v2giso1_prechargereq(
 		tvb, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVTargetVoltage");
+	value = v2giso1_physicalvalue_to_double(&req->EVTargetVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_target_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso1_physicalvalue(
 		&req->EVTargetCurrent,
 		tvb, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVTargetCurrent");
+	value = v2giso1_physicalvalue_to_double(&req->EVTargetCurrent);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_target_current,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	return;
 }
@@ -4095,6 +4136,7 @@ dissect_v2giso1_prechargeres(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4115,6 +4157,11 @@ dissect_v2giso1_prechargeres(
 		tvb, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVSEPresentVoltage");
+	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_present_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	return;
 }
@@ -4129,6 +4176,7 @@ dissect_v2giso1_currentdemandreq(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4144,12 +4192,22 @@ dissect_v2giso1_currentdemandreq(
 		tvb, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVTargetVoltage");
+	value = v2giso1_physicalvalue_to_double(&req->EVTargetVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_target_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso1_physicalvalue(
 		&req->EVTargetCurrent,
 		tvb, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVTargetCurrent");
+	value = v2giso1_physicalvalue_to_double(&req->EVTargetCurrent);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_target_current,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	it = proto_tree_add_int(subtree,
 		hf_v2giso1_struct_iso1CurrentDemandReqType_ChargingComplete,
@@ -4216,6 +4274,7 @@ dissect_v2giso1_currentdemandres(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4236,12 +4295,22 @@ dissect_v2giso1_currentdemandres(
 		tvb, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVSEPresentVoltage");
+	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_present_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso1_physicalvalue(
 		&res->EVSEPresentCurrent,
 		tvb, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVSEPresentCurrent");
+	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentCurrent);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_present_current,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	it = proto_tree_add_int(subtree,
 		hf_v2giso1_struct_iso1CurrentDemandResType_EVSECurrentLimitAchieved,
@@ -4341,6 +4410,7 @@ dissect_v2giso1_weldingdetectionres(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -4359,6 +4429,11 @@ dissect_v2giso1_weldingdetectionres(
 		&res->EVSEPresentVoltage,
 		tvb, subtree, ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVSEPresentVoltage");
+	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_present_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	return;
 }
@@ -5662,6 +5737,24 @@ proto_register_v2giso1(void)
 		    "v2giso1.struct.weldingdetectionres.responsecode",
 		    FT_UINT32, BASE_DEC, VALS(v2giso1_response_code_names),
 		    0x0, NULL, HFILL }
+		},
+
+		/* Derived values for graphing */
+		{ &hf_v2giso1_target_voltage,
+		  { "Voltage", "v2giso1.target.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_target_current,
+		  { "Current", "v2giso1.target.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_present_voltage,
+		  { "Voltage", "v2giso1.present.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_present_current,
+		  { "Current", "v2giso1.present.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		}
 	};
 


### PR DESCRIPTION
To support graphing add in specific generated headers for voltage and
current that can be used for the Y field in the I/O graphs.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>