### PR TITLE
dissector/v2gexi: handshake will sometimes include the nil char

### DIFF
--- a/src/packet-v2gexi.c
+++ b/src/packet-v2gexi.c
@@ -151,7 +151,7 @@ dissect_v2gexi_apphandappprotocoltype(
 
 	/* DIN */
 	const char ns0[] = "urn:din:70121:2012:MsgDef";
-	if ((strlen(ns0) ==
+	if ((strlen(ns0) <=
 	     apphandappprotocol->ProtocolNamespace.charactersLen) &&
 	    (exi_strncasecmp(apphandappprotocol->ProtocolNamespace.characters,
 			     ns0, strlen(ns0)) == 0)) {
@@ -164,7 +164,7 @@ dissect_v2gexi_apphandappprotocoltype(
 
 	/* ISO1 */
 	const char ns1[] = "urn:iso:15118:2:2013:MsgDef";
-	if ((strlen(ns1) ==
+	if ((strlen(ns1) <=
 	     apphandappprotocol->ProtocolNamespace.charactersLen) &&
 	    (exi_strncasecmp(apphandappprotocol->ProtocolNamespace.characters,
 			     ns1, strlen(ns1)) == 0)) {
@@ -177,7 +177,7 @@ dissect_v2gexi_apphandappprotocoltype(
 
 	/* ISO2 */
 	const char ns2[] = "urn:iso:15118:2:2016:MsgDef";
-	if ((strlen(ns2) ==
+	if ((strlen(ns2) <=
 	     apphandappprotocol->ProtocolNamespace.charactersLen) &&
 	    (exi_strncasecmp(apphandappprotocol->ProtocolNamespace.characters,
 			     ns2, strlen(ns2)) == 0)) {


### PR DESCRIPTION
Some EVs are encoding the full string will nil at the end and some
are not. So, to handle the prefix case in this pattern just make
sure the string is long enough to compare but is doesn't need to
be exact. This should up when the CharactersLen was 26 instead of
the expected 25 and the last char was a '\0'.

    [0] = u(75)
    [1] = r(72)
    [2] = n(6e)
    [3] = :(3a)
    [4] = d(64)
    [5] = i(69)
    [6] = n(6e)
    [7] = :(3a)
    [8] = 7(37)
    [9] = 0(30)
    [10] = 1(31)
    [11] = 2(32)
    [12] = 1(31)
    [13] = :(3a)
    [14] = 2(32)
    [15] = 0(30)
    [16] = 1(31)
    [17] = 2(32)
    [18] = :(3a)
    [19] = M(4d)
    [20] = s(73)
    [21] = g(67)
    [22] = D(44)
    [23] = e(65)
    [24] = f(66)
    [25] = ^@(0)  <--- HERE

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>