### PR TITLE
src: add in the missing the index prints for the array decodes

### DIFF
--- a/src/packet-v2gdin.c
+++ b/src/packet-v2gdin.c
@@ -1691,6 +1691,7 @@ dissect_v2gdin_servicetaglist(
 	for (i = 0; i < servicetaglist->Service.arrayLen; i++) {
 		char index[sizeof("[65536]")];
 
+		snprintf(index, sizeof(index), "[%u]", i);
 		dissect_v2gdin_service(
 			&servicetaglist->Service.array[i],
 			tvb, pinfo, service_tree,
@@ -1853,6 +1854,7 @@ dissect_v2gdin_parameterset(
 	for (i = 0; i < parameterset->Parameter.arrayLen; i++) {
 		char index[sizeof("[65536]")];
 
+		snprintf(index, sizeof(index), "[%u]", i);
 		dissect_v2gdin_parameter(
 			&parameterset->Parameter.array[i],
 			tvb, pinfo, parameter_tree,
@@ -1883,6 +1885,7 @@ dissect_v2gdin_serviceparameterlist(
 	for (i = 0; i < serviceparameterlist->ParameterSet.arrayLen; i++) {
 		char index[sizeof("[65536]")];
 
+		snprintf(index, sizeof(index), "[%u]", i);
 		dissect_v2gdin_parameterset(
 			&serviceparameterlist->ParameterSet.array[i],
 			tvb, pinfo, parameterset_tree,

--- a/src/packet-v2giso1.c
+++ b/src/packet-v2giso1.c
@@ -1924,6 +1924,7 @@ dissect_v2giso1_parameterset(
 	for (i = 0; i < parameterset->Parameter.arrayLen; i++) {
 		char index[sizeof("[65536]")];
 
+		snprintf(index, sizeof(index), "[%u]", i);
 		dissect_v2giso1_parameter(
 			&parameterset->Parameter.array[i],
 			tvb, pinfo, parameter_tree,
@@ -1954,6 +1955,7 @@ dissect_v2giso1_serviceparameterlist(
 	for (i = 0; i < serviceparameterlist->ParameterSet.arrayLen; i++) {
 		char index[sizeof("[65536]")];
 
+		snprintf(index, sizeof(index), "[%u]", i);
 		dissect_v2giso1_parameterset(
 			&serviceparameterlist->ParameterSet.array[i],
 			tvb, pinfo, parameterset_tree,
@@ -2014,6 +2016,7 @@ dissect_v2giso1_selectedservicelist(
 	for (i = 0; i < selectedservicelist->SelectedService.arrayLen; i++) {
 		char index[sizeof("[65536]")];
 
+		snprintf(index, sizeof(index), "[%u]", i);
 		dissect_v2giso1_selectedservice(
 			&selectedservicelist->SelectedService.array[i],
 			tvb, pinfo, selectedservice_tree,


### PR DESCRIPTION
The array index is used as the subtree name, so without filling out the character array the decoder uses the unitialized stack.

Fixes #26

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>