### PR TITLE
src: add the register stream follow functions for sub-dissectors

### DIFF
--- a/src/packet-v2gdin.c
+++ b/src/packet-v2gdin.c
@@ -19,6 +19,7 @@
 #include <epan/packet.h>
 #include <epan/prefs.h>
 #include <epan/expert.h>
+#include <epan/follow.h>
 
 /* openv2g */
 #include <codec/EXITypes.h>
@@ -5846,6 +5847,13 @@ proto_register_v2gdin(void)
 	proto_register_subtree_array(ett, array_length(ett));
 
 	register_dissector("v2gdin", dissect_v2gdin, proto_v2gdin);
+
+	register_follow_stream(proto_v2gdin, "v2gdin_follow",
+		tcp_follow_conv_filter,
+		tcp_follow_index_filter,
+		tcp_follow_address_filter,
+		tcp_port_to_display, follow_tvb_tap_listener,
+		get_tcp_stream_count, NULL);
 }
 
 

--- a/src/packet-v2giso1.c
+++ b/src/packet-v2giso1.c
@@ -13,6 +13,7 @@
 #include <epan/packet.h>
 #include <epan/prefs.h>
 #include <epan/expert.h>
+#include <epan/follow.h>
 
 /* openv2g */
 #include <codec/EXITypes.h>
@@ -6083,6 +6084,13 @@ proto_register_v2giso1(void)
 	proto_register_subtree_array(ett, array_length(ett));
 
 	register_dissector("v2giso1", dissect_v2giso1, proto_v2giso1);
+
+	register_follow_stream(proto_v2giso1, "v2giso1_follow",
+		tcp_follow_conv_filter,
+		tcp_follow_index_filter,
+		tcp_follow_address_filter,
+		tcp_port_to_display, follow_tvb_tap_listener,
+		get_tcp_stream_count, NULL);
 }
 
 

--- a/src/packet-v2giso2.c
+++ b/src/packet-v2giso2.c
@@ -13,6 +13,7 @@
 #include <epan/packet.h>
 #include <epan/prefs.h>
 #include <epan/expert.h>
+#include <epan/follow.h>
 
 /* openv2g */
 #include <codec/EXITypes.h>
@@ -9602,6 +9603,13 @@ proto_register_v2giso2(void)
 	proto_register_subtree_array(ett, array_length(ett));
 
 	register_dissector("v2giso2", dissect_v2giso2, proto_v2giso2);
+
+	register_follow_stream(proto_v2giso2, "v2giso2_follow",
+		tcp_follow_conv_filter,
+		tcp_follow_index_filter,
+		tcp_follow_address_filter,
+		tcp_port_to_display, follow_tvb_tap_listener,
+		get_tcp_stream_count, NULL);
 }
 
 void


### PR DESCRIPTION
In the general sense, the packet capture tries to decode the handshake to determine what the EXI schema grammer to use should be. So, in the case when a pcap does not have a handshake allow a stream to be followed and decoded as expected.