### PR TITLE
exi_add_characters: escape non-printing and non-ASCII characters

### DIFF
--- a/src/v2gexi.h
+++ b/src/v2gexi.h
@@ -61,8 +61,8 @@ exi_add_characters(proto_tree *tree,
 		return;
 	}
 
-	/* worst-case string length, assume every character is "\u{0x1fffff}" */
-	str = malloc(characterslen * 12 + 1);
+	/* worst-case string length, assume every character is "\u{1fffff}" */
+	str = malloc(characterslen * 10 + 1);
 	if (str == NULL) {
 		return;
 	}


### PR DESCRIPTION
If the character has a C string escape sequence, that sequence is used as its representation. Otherwise, it is represented as an even number of hexadigits inside \u{...}.

Fixes #44