### PR TITLE
tools/vagrant: update the box reference to Ubuntu 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,7 @@ set(DISSECTOR_SRC
     src/packet-v2giso2.c
 )
 
-set(PLUGIN_FILES
-    plugin.c
-    ${DISSECTOR_SRC}
-)
-
-set_source_files_properties(${PLUGIN_FILES}
+set_source_files_properties(${DISSECTOR_SRC}
     PROPERTIES
         COMPILE_FLAGS "${WERROR_COMMON_FLAGS}"
 )
@@ -58,6 +53,10 @@ find_package(Wireshark)
 if(Wireshark_FOUND)
 
     message(STATUS "Wireshark found in ${Wireshark_LIB_DIR}")
+
+    if(NOT Wireshark_PLUGINS_ENABLED)
+        message(WARNING "Wireshark was compiled without support for plugins")
+    endif()
 
     if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
         set(CMAKE_INSTALL_PREFIX "${Wireshark_INSTALL_PREFIX}"
@@ -84,6 +83,7 @@ if(Wireshark_FOUND)
     endif(APPLE)
 
     add_library(v2gexi MODULE
+        src/v2gplugin.c
         ${DISSECTOR_SRC}
     )
 

--- a/src/v2gplugin.c
+++ b/src/v2gplugin.c
@@ -1,0 +1,52 @@
+/*
+ * Do not modify this file. Changes will be overwritten.
+ *
+ * Generated automatically from make-plugin-reg.py.
+ */
+
+/* plugins are DLLs on Windows */
+#define WS_BUILD_DLL
+#include "ws_symbol_export.h"
+
+#include <wireshark.h>
+#include <epan/packet.h>
+#include <epan/proto.h>
+
+void proto_register_v2gdin(void);
+void proto_register_v2gexi(void);
+void proto_register_v2giso1(void);
+void proto_register_v2giso2(void);
+void proto_reg_handoff_v2gdin(void);
+void proto_reg_handoff_v2gexi(void);
+void proto_reg_handoff_v2giso1(void);
+void proto_reg_handoff_v2giso2(void);
+
+WS_DLL_PUBLIC_DEF const gchar plugin_version[] = VERSION;
+WS_DLL_PUBLIC_DEF const int plugin_want_major = WIRESHARK_VERSION_MAJOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_minor = WIRESHARK_VERSION_MINOR;
+
+WS_DLL_PUBLIC void plugin_register(void);
+
+void plugin_register(void)
+{
+    static proto_plugin plug_v2gdin;
+
+    plug_v2gdin.register_protoinfo = proto_register_v2gdin;
+    plug_v2gdin.register_handoff = proto_reg_handoff_v2gdin;
+    proto_register_plugin(&plug_v2gdin);
+    static proto_plugin plug_v2gexi;
+
+    plug_v2gexi.register_protoinfo = proto_register_v2gexi;
+    plug_v2gexi.register_handoff = proto_reg_handoff_v2gexi;
+    proto_register_plugin(&plug_v2gexi);
+    static proto_plugin plug_v2giso1;
+
+    plug_v2giso1.register_protoinfo = proto_register_v2giso1;
+    plug_v2giso1.register_handoff = proto_reg_handoff_v2giso1;
+    proto_register_plugin(&plug_v2giso1);
+    static proto_plugin plug_v2giso2;
+
+    plug_v2giso2.register_protoinfo = proto_register_v2giso2;
+    plug_v2giso2.register_handoff = proto_reg_handoff_v2giso2;
+    proto_register_plugin(&plug_v2giso2);
+}

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -12,10 +12,10 @@ sed -i -e 's/^#X11UseLocalhost.*$/X11UseLocalhost no/g' /etc/ssh/sshd_config
 add-apt-repository ppa:wireshark-dev/stable -y
 
 # Install build requirements
-apt-get -y update
-apt-get purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine
+apt -y update
+apt purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine
 gem install asciidoctor
-DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential \
+DEBIAN_FRONTEND=noninteractive apt -y install build-essential \
 	cmake \
 	tshark \
 	wireshark \
@@ -31,10 +31,10 @@ sed -i -e 's/^#X11UseLocalhost.*$/X11UseLocalhost no/g' /etc/ssh/sshd_config
 /etc/init.d/ssh restart
 
 # Install build requirements
-apt-get -y update
-apt-get purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine
+apt -y update
+apt purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine
 gem install asciidoctor
-DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential \
+DEBIAN_FRONTEND=noninteractive apt -y install build-essential \
 	cmake \
 	bison flex \
 	python3 python3-pip perl \
@@ -42,7 +42,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential \
 	qttools5-dev-tools \
 	libqt5svg5-dev \
 	qtmultimedia5-dev \
-	qt5-default \
+	qtbase5-dev \
 	libc-ares-dev \
 	libpcap-dev \
 	libgcrypt-dev \
@@ -80,7 +80,7 @@ Vagrant.configure(2) do |config|
   config.ssh.forward_x11 = true
 
   # box
-  config.vm.box = "generic/ubuntu2004"
+  config.vm.box = "generic/ubuntu2204"
   config.vm.synced_folder ".", "/vagrant", disabled: true
   vagrant_root = File.join(File.dirname(__FILE__), "..", "..")
   config.vm.provision "shell", name: "bootstrap",
@@ -113,7 +113,7 @@ Vagrant.configure(2) do |config|
       name: "bootstrap-source",
       privileged: true,
       inline: $bootstrap_source,
-      env: {"WIRESHARK_BRANCH" => "release-3.6",
+      env: {"WIRESHARK_BRANCH" => "release-4.0",
             "PLUGIN_DIR" => "/home/vagrant/wireshark-v2g/"}
   end
 end


### PR DESCRIPTION
Trying to reproduce the standalone issue reported for unknown symbols

    # vagrant adds the wireshark-dev repo and packages
    vagrant up
    vagrant ssh

    mkdir build && cd build
    cmake ../wireshark-v2g
    make
    sudo make install

Fixes: #41 