### PR TITLE
feat(dissector): add more derived values for current demand

### DIFF
--- a/src/packet-v2gdin.c
+++ b/src/packet-v2gdin.c
@@ -261,10 +261,18 @@ static int hf_v2gdin_struct_dinCurrentDemandResType_EVSEPowerLimitAchieved = -1;
 static int hf_v2gdin_struct_dinWeldingDetectionResType_ResponseCode = -1;
 
 /* Specifically track voltage and current for graphing */
-static int hf_v2gdin_target_voltage = -1;
-static int hf_v2gdin_target_current = -1;
-static int hf_v2gdin_present_voltage = -1;
-static int hf_v2gdin_present_current = -1;
+static int hf_v2gdin_ev_target_voltage = -1;
+static int hf_v2gdin_ev_target_current = -1;
+static int hf_v2gdin_ev_maximum_voltage_limit = -1;
+static int hf_v2gdin_ev_maximum_current_limit = -1;
+static int hf_v2gdin_ev_maximum_power_limit = -1;
+static int hf_v2gdin_remaining_time_to_full_soc = -1;
+static int hf_v2gdin_remaining_time_to_bulk_soc = -1;
+static int hf_v2gdin_evse_present_voltage = -1;
+static int hf_v2gdin_evse_present_current = -1;
+static int hf_v2gdin_evse_maximum_voltage_limit = -1;
+static int hf_v2gdin_evse_maximum_current_limit = -1;
+static int hf_v2gdin_evse_maximum_power_limit = -1;
 
 /* Initialize the subtree pointers */
 static gint ett_v2gdin = -1;
@@ -2177,6 +2185,7 @@ dissect_v2gdin_dc_evchargeparameter(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree, tvb, 0, 0,
 		idx, NULL, subtree_name);
@@ -2191,12 +2200,24 @@ dissect_v2gdin_dc_evchargeparameter(
 		tvb, pinfo, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVMaximumVoltageLimit");
+	value = v2gdin_physicalvalue_to_double(
+		&dc_evchargeparameter->EVMaximumVoltageLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_ev_maximum_voltage_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2gdin_physicalvalue(
 		&dc_evchargeparameter->EVMaximumCurrentLimit,
 		tvb, pinfo, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVMaximumCurrentLimit");
+	value = v2gdin_physicalvalue_to_double(
+		&dc_evchargeparameter->EVMaximumCurrentLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_ev_maximum_current_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	if (dc_evchargeparameter->EVMaximumPowerLimit_isUsed) {
 		dissect_v2gdin_physicalvalue(
@@ -2204,6 +2225,12 @@ dissect_v2gdin_dc_evchargeparameter(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVMaximumPowertLimit");
+		value = v2gdin_physicalvalue_to_double(
+			&dc_evchargeparameter->EVMaximumPowerLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_ev_maximum_power_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (dc_evchargeparameter->EVEnergyCapacity_isUsed) {
@@ -2383,6 +2410,8 @@ dissect_v2gdin_dc_evsechargeparameter(
 	const char *subtree_name)
 {
 	proto_tree *subtree;
+	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree, tvb, 0, 0,
 		idx, NULL, subtree_name);
@@ -2396,6 +2425,12 @@ dissect_v2gdin_dc_evsechargeparameter(
 		tvb, pinfo, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVSEMaximumVoltageLimit");
+	value = v2gdin_physicalvalue_to_double(
+		&dc_evsechargeparameter->EVSEMaximumVoltageLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_evse_maximum_voltage_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2gdin_physicalvalue(
 		&dc_evsechargeparameter->EVSEMinimumVoltageLimit,
@@ -2408,6 +2443,12 @@ dissect_v2gdin_dc_evsechargeparameter(
 		tvb, pinfo, subtree,
 		ett_v2gdin_struct_dinPhysicalValueType,
 		"EVSEMaximumCurrentLimit");
+	value = v2gdin_physicalvalue_to_double(
+		&dc_evsechargeparameter->EVSEMaximumCurrentLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2gdin_evse_maximum_current_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2gdin_physicalvalue(
 		&dc_evsechargeparameter->EVSEMinimumCurrentLimit,
@@ -2421,6 +2462,12 @@ dissect_v2gdin_dc_evsechargeparameter(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVSEMaximumPowerLimit");
+		value = v2gdin_physicalvalue_to_double(
+			&dc_evsechargeparameter->EVSEMaximumPowerLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_evse_maximum_power_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (dc_evsechargeparameter->EVSECurrentRegulationTolerance_isUsed) {
@@ -4112,7 +4159,7 @@ dissect_v2gdin_prechargereq(
 		"EVTargetVoltage");
 	value = v2gdin_physicalvalue_to_double(&req->EVTargetVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_target_voltage,
+		hf_v2gdin_ev_target_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4123,7 +4170,7 @@ dissect_v2gdin_prechargereq(
 		"EVTargetCurrent");
 	value = v2gdin_physicalvalue_to_double(&req->EVTargetCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_target_current,
+		hf_v2gdin_ev_target_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4164,7 +4211,7 @@ dissect_v2gdin_prechargeres(
 		"EVSEPresentVoltage");
 	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_present_voltage,
+		hf_v2gdin_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4200,7 +4247,7 @@ dissect_v2gdin_currentdemandreq(
 		"EVTargetVoltage");
 	value = v2gdin_physicalvalue_to_double(&req->EVTargetVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_target_voltage,
+		hf_v2gdin_ev_target_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4211,7 +4258,7 @@ dissect_v2gdin_currentdemandreq(
 		"EVTargetCurrent");
 	value = v2gdin_physicalvalue_to_double(&req->EVTargetCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_target_current,
+		hf_v2gdin_ev_target_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4233,6 +4280,11 @@ dissect_v2gdin_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVMaximumVoltageLimit");
+		value = v2gdin_physicalvalue_to_double(&req->EVMaximumVoltageLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_ev_maximum_voltage_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->EVMaximumCurrentLimit_isUsed) {
@@ -4241,6 +4293,11 @@ dissect_v2gdin_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVMaximumCurrentLimit");
+		value = v2gdin_physicalvalue_to_double(&req->EVMaximumCurrentLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_ev_maximum_current_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->EVMaximumPowerLimit_isUsed) {
@@ -4249,6 +4306,11 @@ dissect_v2gdin_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVMaximumPowerLimit");
+		value = v2gdin_physicalvalue_to_double(&req->EVMaximumPowerLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_ev_maximum_power_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->RemainingTimeToFullSoC_isUsed) {
@@ -4257,6 +4319,11 @@ dissect_v2gdin_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"RemainingTimeToFullSoC");
+		value = v2gdin_physicalvalue_to_double(&req->RemainingTimeToFullSoC);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_remaining_time_to_full_soc,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->RemainingTimeToBulkSoC_isUsed) {
@@ -4265,6 +4332,11 @@ dissect_v2gdin_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"RemainingTimeToBulkSoC");
+		value = v2gdin_physicalvalue_to_double(&req->RemainingTimeToBulkSoC);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_remaining_time_to_bulk_soc,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	return;
@@ -4304,7 +4376,7 @@ dissect_v2gdin_currentdemandres(
 		"EVSEPresentVoltage");
 	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_present_voltage,
+		hf_v2gdin_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4315,7 +4387,7 @@ dissect_v2gdin_currentdemandres(
 		"EVSEPresentCurrent");
 	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_present_current,
+		hf_v2gdin_evse_present_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4340,6 +4412,11 @@ dissect_v2gdin_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVSEMaximumVoltageLimit");
+		value = v2gdin_physicalvalue_to_double(&res->EVSEMaximumVoltageLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_evse_maximum_voltage_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 	if (res->EVSEMaximumCurrentLimit_isUsed) {
 		dissect_v2gdin_physicalvalue(
@@ -4347,6 +4424,11 @@ dissect_v2gdin_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVSEMaximumCurrentLimit");
+		value = v2gdin_physicalvalue_to_double(&res->EVSEMaximumCurrentLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_evse_maximum_current_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 	if (res->EVSEMaximumPowerLimit_isUsed) {
 		dissect_v2gdin_physicalvalue(
@@ -4354,6 +4436,11 @@ dissect_v2gdin_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2gdin_struct_dinPhysicalValueType,
 			"EVSEMaximumPowerLimit");
+		value = v2gdin_physicalvalue_to_double(&res->EVSEMaximumPowerLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2gdin_evse_maximum_power_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	return;
@@ -4415,7 +4502,7 @@ dissect_v2gdin_weldingdetectionres(
 		"EVSEPresentVoltage");
 	value = v2gdin_physicalvalue_to_double(&res->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2gdin_present_voltage,
+		hf_v2gdin_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -5729,20 +5816,62 @@ proto_register_v2gdin(void)
 		},
 
 		/* Derived values for graphing */
-		{ &hf_v2gdin_target_voltage,
-		  { "Voltage", "v2gdin.target.voltage",
+		{ &hf_v2gdin_ev_target_voltage,
+		  { "EV Target Voltage (derived)", "v2gdin.ev.target.voltage",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2gdin_target_current,
-		  { "Current", "v2gdin.target.current",
+		{ &hf_v2gdin_ev_target_current,
+		  { "EV Target Current (derived)", "v2gdin.ev.target.current",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2gdin_present_voltage,
-		  { "Voltage", "v2gdin.present.voltage",
+		{ &hf_v2gdin_ev_maximum_voltage_limit,
+		  { "EV Maximum Voltage Limit (derived)",
+		    "v2gdin.ev.maximum.voltage.limit",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2gdin_present_current,
-		  { "Current", "v2gdin.present.current",
+		{ &hf_v2gdin_ev_maximum_current_limit,
+		  { "EV Maximum Current Limit (derived)",
+		    "v2gdin.ev.maximum.current.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_ev_maximum_power_limit,
+		  { "EV Maximum Power Limit (derived)",
+		    "v2gdin.ev.maximum.power.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_remaining_time_to_full_soc,
+		  { "Remaining Time to Full SOC (derived)",
+		    "v2gdin.remaining.time.to.full.soc",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_remaining_time_to_bulk_soc,
+		  { "Remaining Time to Bulk SOC (derived)",
+		    "v2gdin.remaining.time.to.bulk.soc",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_evse_present_voltage,
+		  { "EVSE Present Voltage (derived)",
+		    "v2gdin.evse.present.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_evse_present_current,
+		  { "EVSE Present Current (derived)",
+		    "v2gdin.evse.present.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_evse_maximum_voltage_limit,
+		  { "EVSE Maximum Voltage Limit (derived)",
+		    "v2gdin.evse.maximum.voltage.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_evse_maximum_current_limit,
+		  { "EVSE Maximum Current Limit (derived)",
+		    "v2gdin.evse.maximum.current.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2gdin_evse_maximum_power_limit,
+		  { "EVSE Maximum Power Limit (derived)",
+		    "v2gdin.evse.maximum.power.limit",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		}
 	};

--- a/src/packet-v2giso1.c
+++ b/src/packet-v2giso1.c
@@ -256,10 +256,18 @@ static int hf_v2giso1_struct_iso1CurrentDemandResType_ReceiptRequired = -1;
 static int hf_v2giso1_struct_iso1WeldingDetectionResType_ResponseCode = -1;
 
 /* Specifically track voltage and current for graphing */
-static int hf_v2giso1_target_voltage = -1;
-static int hf_v2giso1_target_current = -1;
-static int hf_v2giso1_present_voltage = -1;
-static int hf_v2giso1_present_current = -1;
+static int hf_v2giso1_ev_target_voltage = -1;
+static int hf_v2giso1_ev_target_current = -1;
+static int hf_v2giso1_ev_maximum_voltage_limit = -1;
+static int hf_v2giso1_ev_maximum_current_limit = -1;
+static int hf_v2giso1_ev_maximum_power_limit = -1;
+static int hf_v2giso1_remaining_time_to_full_soc = -1;
+static int hf_v2giso1_remaining_time_to_bulk_soc = -1;
+static int hf_v2giso1_evse_present_voltage = -1;
+static int hf_v2giso1_evse_present_current = -1;
+static int hf_v2giso1_evse_maximum_voltage_limit = -1;
+static int hf_v2giso1_evse_maximum_current_limit = -1;
+static int hf_v2giso1_evse_maximum_power_limit = -1;
 
 /* Initialize the subtree pointers */
 static gint ett_v2giso1 = -1;
@@ -2258,6 +2266,7 @@ dissect_v2giso1_dc_evchargeparameter(
 {
 	proto_tree *subtree;
 	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree, tvb, 0, 0,
 		idx, NULL, subtree_name);
@@ -2278,12 +2287,24 @@ dissect_v2giso1_dc_evchargeparameter(
 		tvb, pinfo, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVMaximumVoltageLimit");
+	value = v2giso1_physicalvalue_to_double(
+		&dc_evchargeparameter->EVMaximumVoltageLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_ev_maximum_voltage_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso1_physicalvalue(
 		&dc_evchargeparameter->EVMaximumCurrentLimit,
 		tvb, pinfo, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVMaximumCurrentLimit");
+	value = v2giso1_physicalvalue_to_double(
+		&dc_evchargeparameter->EVMaximumCurrentLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_ev_maximum_current_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	if (dc_evchargeparameter->EVMaximumPowerLimit_isUsed) {
 		dissect_v2giso1_physicalvalue(
@@ -2291,6 +2312,12 @@ dissect_v2giso1_dc_evchargeparameter(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"EVMaximumPowertLimit");
+		value = v2giso1_physicalvalue_to_double(
+			&dc_evchargeparameter->EVMaximumPowerLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_ev_maximum_power_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (dc_evchargeparameter->EVEnergyCapacity_isUsed) {
@@ -2483,6 +2510,8 @@ dissect_v2giso1_dc_evsechargeparameter(
 	const char *subtree_name)
 {
 	proto_tree *subtree;
+	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree, tvb, 0, 0,
 		idx, NULL, subtree_name);
@@ -2497,6 +2526,12 @@ dissect_v2giso1_dc_evsechargeparameter(
 		tvb, pinfo, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVSEMaximumVoltageLimit");
+	value = v2giso1_physicalvalue_to_double(
+		&dc_evsechargeparameter->EVSEMaximumVoltageLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_evse_maximum_voltage_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso1_physicalvalue(
 		&dc_evsechargeparameter->EVSEMinimumVoltageLimit,
@@ -2509,6 +2544,12 @@ dissect_v2giso1_dc_evsechargeparameter(
 		tvb, pinfo, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVSEMaximumCurrentLimit");
+	value = v2giso1_physicalvalue_to_double(
+		&dc_evsechargeparameter->EVSEMaximumCurrentLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_evse_maximum_current_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso1_physicalvalue(
 		&dc_evsechargeparameter->EVSEMinimumCurrentLimit,
@@ -2521,6 +2562,12 @@ dissect_v2giso1_dc_evsechargeparameter(
 		tvb, pinfo, subtree,
 		ett_v2giso1_struct_iso1PhysicalValueType,
 		"EVSEMaximumPowerLimit");
+	value = v2giso1_physicalvalue_to_double(
+		&dc_evsechargeparameter->EVSEMaximumPowerLimit);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso1_evse_maximum_power_limit,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	if (dc_evsechargeparameter->EVSECurrentRegulationTolerance_isUsed) {
 		dissect_v2giso1_physicalvalue(
@@ -4315,7 +4362,7 @@ dissect_v2giso1_prechargereq(
 		"EVTargetVoltage");
 	value = v2giso1_physicalvalue_to_double(&req->EVTargetVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_target_voltage,
+		hf_v2giso1_ev_target_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4326,7 +4373,7 @@ dissect_v2giso1_prechargereq(
 		"EVTargetCurrent");
 	value = v2giso1_physicalvalue_to_double(&req->EVTargetCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_target_current,
+		hf_v2giso1_ev_target_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4367,7 +4414,7 @@ dissect_v2giso1_prechargeres(
 		"EVSEPresentVoltage");
 	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_present_voltage,
+		hf_v2giso1_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4403,7 +4450,7 @@ dissect_v2giso1_currentdemandreq(
 		"EVTargetVoltage");
 	value = v2giso1_physicalvalue_to_double(&req->EVTargetVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_target_voltage,
+		hf_v2giso1_ev_target_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4414,7 +4461,7 @@ dissect_v2giso1_currentdemandreq(
 		"EVTargetCurrent");
 	value = v2giso1_physicalvalue_to_double(&req->EVTargetCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_target_current,
+		hf_v2giso1_ev_target_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4436,6 +4483,11 @@ dissect_v2giso1_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"EVMaximumVoltageLimit");
+		value = v2giso1_physicalvalue_to_double(&req->EVMaximumVoltageLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_ev_maximum_voltage_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->EVMaximumCurrentLimit_isUsed) {
@@ -4444,6 +4496,11 @@ dissect_v2giso1_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"EVMaximumCurrentLimit");
+		value = v2giso1_physicalvalue_to_double(&req->EVMaximumCurrentLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_ev_maximum_current_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->EVMaximumPowerLimit_isUsed) {
@@ -4452,6 +4509,11 @@ dissect_v2giso1_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"EVMaximumPowerLimit");
+		value = v2giso1_physicalvalue_to_double(&req->EVMaximumPowerLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_ev_maximum_power_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->RemainingTimeToFullSoC_isUsed) {
@@ -4460,6 +4522,11 @@ dissect_v2giso1_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"RemainingTimeToFullSoC");
+		value = v2giso1_physicalvalue_to_double(&req->RemainingTimeToFullSoC);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_remaining_time_to_full_soc,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (req->RemainingTimeToBulkSoC_isUsed) {
@@ -4468,6 +4535,11 @@ dissect_v2giso1_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"RemainingTimeToBulkSoC");
+		value = v2giso1_physicalvalue_to_double(&req->RemainingTimeToBulkSoC);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_remaining_time_to_bulk_soc,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	return;
@@ -4507,7 +4579,7 @@ dissect_v2giso1_currentdemandres(
 		"EVSEPresentVoltage");
 	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_present_voltage,
+		hf_v2giso1_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4518,7 +4590,7 @@ dissect_v2giso1_currentdemandres(
 		"EVSEPresentCurrent");
 	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_present_current,
+		hf_v2giso1_evse_present_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4543,6 +4615,11 @@ dissect_v2giso1_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"EVSEMaximumVoltageLimit");
+		value = v2giso1_physicalvalue_to_double(&res->EVSEMaximumVoltageLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_evse_maximum_voltage_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 	if (res->EVSEMaximumCurrentLimit_isUsed) {
 		dissect_v2giso1_physicalvalue(
@@ -4550,6 +4627,11 @@ dissect_v2giso1_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"EVSEMaximumCurrentLimit");
+		value = v2giso1_physicalvalue_to_double(&res->EVSEMaximumCurrentLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_evse_maximum_current_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 	if (res->EVSEMaximumPowerLimit_isUsed) {
 		dissect_v2giso1_physicalvalue(
@@ -4557,6 +4639,11 @@ dissect_v2giso1_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2giso1_struct_iso1PhysicalValueType,
 			"EVSEMaximumPowerLimit");
+		value = v2giso1_physicalvalue_to_double(&res->EVSEMaximumPowerLimit);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso1_evse_maximum_power_limit,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	exi_add_characters(subtree,
@@ -4644,7 +4731,7 @@ dissect_v2giso1_weldingdetectionres(
 		"EVSEPresentVoltage");
 	value = v2giso1_physicalvalue_to_double(&res->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso1_present_voltage,
+		hf_v2giso1_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -5960,20 +6047,62 @@ proto_register_v2giso1(void)
 		},
 
 		/* Derived values for graphing */
-		{ &hf_v2giso1_target_voltage,
-		  { "Voltage", "v2giso1.target.voltage",
+		{ &hf_v2giso1_ev_target_voltage,
+		  { "EV Target Voltage (derived)", "v2giso1.ev.target.voltage",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2giso1_target_current,
-		  { "Current", "v2giso1.target.current",
+		{ &hf_v2giso1_ev_target_current,
+		  { "EV Target Current (derived)", "v2giso1.ev.target.current",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2giso1_present_voltage,
-		  { "Voltage", "v2giso1.present.voltage",
+		{ &hf_v2giso1_ev_maximum_voltage_limit,
+		  { "EV Maximum Voltage Limit (derived)",
+		    "v2giso1.ev.maximum.voltage.limit",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2giso1_present_current,
-		  { "Current", "v2giso1.present.current",
+		{ &hf_v2giso1_ev_maximum_current_limit,
+		  { "EV Maximum Current Limit (derived)",
+		    "v2giso1.ev.maximum.current.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_ev_maximum_power_limit,
+		  { "EV Maximum Power Limit (derived)",
+		    "v2giso1.ev.maximum.power.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_remaining_time_to_full_soc,
+		  { "Remaining Time To Full SOC (derived)",
+		    "v2giso1.remaining.time.to.full.soc",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_remaining_time_to_bulk_soc,
+		  { "Remaining Time To Bulk SOC (derived)",
+		    "v2giso1.remaining.time.to.bulk.soc",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_evse_present_voltage,
+		  { "EVSE Present Voltage (derived)",
+		    "v2giso1.evse.present.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_evse_present_current,
+		  { "EVSE Present Current (derived)",
+		    "v2giso1.evse.present.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_evse_maximum_voltage_limit,
+		  { "EVSE Maximum Voltage Limit (derived)",
+		    "v2giso1.evse.maximum.voltage.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_evse_maximum_current_limit,
+		  { "EVSE Maximum Current Limit (derived)",
+		    "v2giso1.evse.maximum.current.limit",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso1_evse_maximum_power_limit,
+		  { "EVSE Maximum Power Limit (derived)",
+		    "v2giso1.evse.maximum.power.limit",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		}
 	};

--- a/src/packet-v2giso2.c
+++ b/src/packet-v2giso2.c
@@ -351,10 +351,16 @@ static int hf_v2giso2_struct_iso2SessionSetupResType_EVSEID = -1;
 static int hf_v2giso2_struct_iso2SessionSetupResType_EVSETimeStamp = -1;
 
 /* Specifically track voltage and current for graphing */
-static int hf_v2giso2_target_voltage = -1;
-static int hf_v2giso2_target_current = -1;
-static int hf_v2giso2_present_voltage = -1;
-static int hf_v2giso2_present_current = -1;
+static int hf_v2giso2_ev_target_voltage = -1;
+static int hf_v2giso2_ev_target_current = -1;
+static int hf_v2giso2_ev_maximum_voltage = -1;
+static int hf_v2giso2_ev_maximum_current = -1;
+static int hf_v2giso2_ev_maximum_power = -1;
+static int hf_v2giso2_evse_present_voltage = -1;
+static int hf_v2giso2_evse_present_current = -1;
+static int hf_v2giso2_evse_maximum_voltage = -1;
+static int hf_v2giso2_evse_maximum_current = -1;
+static int hf_v2giso2_evse_maximum_power = -1;
 
 /* Initialize the subtree pointers */
 static gint ett_v2giso2 = -1;
@@ -4722,7 +4728,7 @@ dissect_v2giso2_dc_bidirectionalcontrolreq(
 	value = v2giso2_physicalvalue_to_double(
 		&dc_bidirectionalcontrolreq->EVTargetCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_target_current,
+		hf_v2giso2_ev_target_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4734,7 +4740,7 @@ dissect_v2giso2_dc_bidirectionalcontrolreq(
 	value = v2giso2_physicalvalue_to_double(
 		&dc_bidirectionalcontrolreq->EVTargetVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_target_voltage,
+		hf_v2giso2_ev_target_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4743,6 +4749,12 @@ dissect_v2giso2_dc_bidirectionalcontrolreq(
 		tvb, pinfo, subtree,
 		ett_v2giso2_struct_iso2PhysicalValueType,
 		"EVMaximumVoltage");
+	value = v2giso2_physicalvalue_to_double(
+		&dc_bidirectionalcontrolreq->EVMaximumVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso2_ev_maximum_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso2_physicalvalue(
 		&dc_bidirectionalcontrolreq->EVMinimumVoltage,
@@ -4821,7 +4833,7 @@ dissect_v2giso2_dc_bidirectionalcontrolres(
 	value = v2giso2_physicalvalue_to_double(
 		&dc_bidirectionalcontrolres->EVSEPresentCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_present_current,
+		hf_v2giso2_evse_present_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -4833,7 +4845,7 @@ dissect_v2giso2_dc_bidirectionalcontrolres(
 	value = v2giso2_physicalvalue_to_double(
 		&dc_bidirectionalcontrolres->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_present_voltage,
+		hf_v2giso2_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -5791,7 +5803,7 @@ dissect_v2giso2_weldingdetectionres(
 	value = v2giso2_physicalvalue_to_double(
 		&weldingdetectionres->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_present_voltage,
+		hf_v2giso2_evse_present_voltage,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -5808,6 +5820,8 @@ dissect_v2giso2_currentdemandreq(
 	const char *subtree_name)
 {
 	proto_tree *subtree;
+	proto_item *it;
+	double value;
 
 	subtree = proto_tree_add_subtree(tree,
 		tvb, 0, 0, idx, NULL, subtree_name);
@@ -5847,12 +5861,24 @@ dissect_v2giso2_currentdemandreq(
 		tvb, pinfo, subtree,
 		ett_v2giso2_struct_iso2PhysicalValueType,
 		"EVTargetCurrent");
+	value = v2giso2_physicalvalue_to_double(
+		&currentdemandreq->EVTargetCurrent);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso2_ev_target_current,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	dissect_v2giso2_physicalvalue(
 		&currentdemandreq->EVTargetVoltage,
 		tvb, pinfo, subtree,
 		ett_v2giso2_struct_iso2PhysicalValueType,
 		"EVTargetVoltage");
+	value = v2giso2_physicalvalue_to_double(
+		&currentdemandreq->EVTargetVoltage);
+	it = proto_tree_add_double(subtree,
+		hf_v2giso2_ev_target_voltage,
+		tvb, 0, 0, value);
+	proto_item_set_generated(it);
 
 	if (currentdemandreq->EVMaximumCurrent_isUsed) {
 		dissect_v2giso2_physicalvalue(
@@ -5860,6 +5886,12 @@ dissect_v2giso2_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso2_struct_iso2PhysicalValueType,
 			"EVMaximumCurrent");
+		value = v2giso2_physicalvalue_to_double(
+			&currentdemandreq->EVMaximumCurrent);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso2_ev_maximum_current,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (currentdemandreq->EVMaximumPower_isUsed) {
@@ -5868,6 +5900,12 @@ dissect_v2giso2_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso2_struct_iso2PhysicalValueType,
 			"EVMaximumPower");
+		value = v2giso2_physicalvalue_to_double(
+			&currentdemandreq->EVMaximumPower);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso2_ev_maximum_power,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (currentdemandreq->EVMaximumVoltage_isUsed) {
@@ -5876,6 +5914,12 @@ dissect_v2giso2_currentdemandreq(
 			tvb, pinfo, subtree,
 			ett_v2giso2_struct_iso2PhysicalValueType,
 			"EVMaximumVoltage");
+		value = v2giso2_physicalvalue_to_double(
+			&currentdemandreq->EVMaximumVoltage);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso2_ev_maximum_voltage,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	return;
@@ -5918,7 +5962,7 @@ dissect_v2giso2_currentdemandres(
 	value = v2giso2_physicalvalue_to_double(
 		&currentdemandres->EVSEPresentCurrent);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_present_current,
+		hf_v2giso2_evse_present_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -5930,7 +5974,7 @@ dissect_v2giso2_currentdemandres(
 	value = v2giso2_physicalvalue_to_double(
 		&currentdemandres->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_present_current,
+		hf_v2giso2_evse_present_current,
 		tvb, 0, 0, value);
 	proto_item_set_generated(it);
 
@@ -5955,6 +5999,12 @@ dissect_v2giso2_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2giso2_struct_iso2PhysicalValueType,
 			"EVSEMaximumPower");
+		value = v2giso2_physicalvalue_to_double(
+			&currentdemandres->EVSEMaximumPower);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso2_evse_maximum_power,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (currentdemandres->EVSEMaximumCurrent_isUsed) {
@@ -5963,6 +6013,12 @@ dissect_v2giso2_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2giso2_struct_iso2PhysicalValueType,
 			"EVSEMaximumCurrent");
+		value = v2giso2_physicalvalue_to_double(
+			&currentdemandres->EVSEMaximumCurrent);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso2_evse_maximum_current,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	if (currentdemandres->EVSEMaximumVoltage_isUsed) {
@@ -5971,6 +6027,12 @@ dissect_v2giso2_currentdemandres(
 			tvb, pinfo, subtree,
 			ett_v2giso2_struct_iso2PhysicalValueType,
 			"EVSEMaximumVoltage");
+		value = v2giso2_physicalvalue_to_double(
+			&currentdemandres->EVSEMaximumVoltage);
+		it = proto_tree_add_double(subtree,
+			hf_v2giso2_evse_maximum_voltage,
+			tvb, 0, 0, value);
+		proto_item_set_generated(it);
 	}
 
 	exi_add_characters(subtree,
@@ -6071,7 +6133,7 @@ dissect_v2giso2_prechargeres(
 	value = v2giso2_physicalvalue_to_double(
 		&prechargeres->EVSEPresentVoltage);
 	it = proto_tree_add_double(subtree,
-		hf_v2giso2_present_current,
+		hf_v2giso2_evse_present_current,
 		tvb, 0, 0, value);
 
 	return;
@@ -9434,22 +9496,54 @@ proto_register_v2giso2(void)
 		},
 
 		/* Derived values for graphing */
-		{ &hf_v2giso2_target_voltage,
-		  { "Voltage", "v2giso2.target.voltage",
+		{ &hf_v2giso2_ev_target_voltage,
+		  { "EV Target Voltage (derived)", "v2giso2.ev.target.voltage",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2giso2_target_current,
-		  { "Current", "v2giso2.target.current",
+		{ &hf_v2giso2_ev_target_current,
+		  { "EV Target Current (derived)", "v2giso2.ev.target.current",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2giso2_present_voltage,
-		  { "Voltage", "v2giso2.present.voltage",
+		{ &hf_v2giso2_ev_maximum_voltage,
+		  { "EV Maximum Voltage (derived)",
+		    "v2giso2.ev.maximum.voltage",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
-		{ &hf_v2giso2_present_current,
-		  { "Current", "v2giso2.present.current",
+		{ &hf_v2giso2_ev_maximum_current,
+		  { "EV Maximum Current (derived)",
+		    "v2giso2.ev.maximum.current",
 		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
+		{ &hf_v2giso2_ev_maximum_power,
+		  { "EV Maximum Power (derived)",
+		    "v2giso2.ev.maximum.power",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso2_evse_present_voltage,
+		  { "EVSE Present Voltage (derived)",
+		    "v2giso2.evse.present.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso2_evse_present_current,
+		  { "EVSE Present Current (derived)",
+		    "v2giso2.evse.present.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso2_evse_maximum_voltage,
+		  { "EVSE Maximum Voltage (derived)",
+		    "v2giso2.evse.maximum.voltage",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso2_evse_maximum_current,
+		  { "EVSE Maximum Current (derived)",
+		    "v2giso2.evse.maximum.current",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_v2giso2_evse_maximum_power,
+		  { "EVSE Maximum Power (derived)",
+		    "v2giso2.evse.maximum.power",
+		    FT_DOUBLE, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		}
 	};
 
 	static gint *ett[] = {


### PR DESCRIPTION
The struct breakout of the physical values as a Multipler, Value, Unit is not conducive to graphing or columns. So, derived more of the values like the limits on current, voltage, power as a computed double to make the presentation a bit easier.

Fixes #50