### PR TITLE
build: update the wireshark base to release-4.2

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ on:
    workflow_call:
 
 env:
-   WIRESHARK_BRANCH: release-4.0
+   WIRESHARK_BRANCH: release-4.2
    WIRESHARK_QT_VERSION: 5.15.3
 
 jobs:
@@ -39,19 +39,10 @@ jobs:
            uses: actions/setup-python@v4
            with:
               python-version: 3.8
-         - name: Install dmgbuild
-           run: pip3 install dmgbuild
-         - name: Install biplist
-           run: pip3 install biplist
-         - name: Set up Ruby 2.6
-           uses: actions/setup-ruby@v1
-           with:
-              ruby-version: '2.6'
          - name: Install brew deps
-           run: ./tools/macos-setup-brew.sh
-         - name: Install asciidoctor
-           run: gem install asciidoctor
-
+           run: ./tools/macos-setup-brew.sh --install-optional --install-doc-deps --install-dmg-deps --install-test-deps
+           env:
+             HOMEBREW_NO_AUTO_UPDATE: 1
          - name: Build in-tree
            run: |
               mkdir build
@@ -59,7 +50,6 @@ jobs:
               cmake -GNinja ..
               ninja
               ninja wireshark_dmg
-
          - name: Upload MacOS artifacts
            uses: actions/upload-artifact@v3
            with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ on:
    workflow_call:
 
 env:
-   WIRESHARK_BRANCH: release-4.0
+   WIRESHARK_BRANCH: release-4.2
 
 jobs:
    standalone:
@@ -50,7 +50,7 @@ jobs:
               git remote add -t "${{ env.WIRESHARK_BRANCH }}" -f origin https://gitlab.com/wireshark/wireshark.git
               git checkout ${{ env.WIRESHARK_BRANCH }}
          - name: Checkout plug-in
-           uses: actions/checkout@v2
+           uses: actions/checkout@v3
            with:
               path: plugins/epan/v2g
          - name: Apply patch
@@ -59,23 +59,18 @@ jobs:
          - name: Install dependencies for a in-tree build
            run: |
               sudo apt-get update -qq
-              sudo tools/debian-setup.sh \
-                  --install-optional \
-                  --install-test-deps \
-                  --install-deb-deps \
-                  python3-pip -y
+              sudo tools/debian-setup.sh --install-all python3-pip -y
          - name: Build in-tree
            run: |
               mkdir build
               cd build
               cmake ..
-              make v2gexi tshark
-
+              make -j$(nproc) v2gexi tshark
          - name: Copy plugin artifact
            run: |
               mkdir v2g-artifact
               cp plugins/epan/v2g/dissector/v2g.lua v2g-artifact/v2g.lua
-              cp build/run/plugins/4.0/epan/v2gexi.so v2g-artifact/v2gexi.so
+              cp build/run/plugins/4.2/epan/v2gexi.so v2g-artifact/v2gexi.so
          - name: Upload Ubuntu artifacts
            uses: actions/upload-artifact@v3
            with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ on:
 
 env:
    PLATFORM: x64
-   WIRESHARK_BRANCH: release-4.0
+   WIRESHARK_BRANCH: release-4.2
    WIRESHARK_BASE_DIR: C:\Development
    CMAKE_PREFIX_PATH: D:\a\wireshark\Qt\6.2.3\msvc2019_64
    WIRESHARK_VERSION_EXTRA: -GithubActionBuild
@@ -38,7 +38,7 @@ jobs:
            run: |
               git apply plugins/epan/v2g/extern/wireshark-${{ env.WIRESHARK_BRANCH }}.patch
          - name: Choco install
-           run: cinst -y --force --no-progress asciidoctorj xsltproc docbook-bundle nsis winflexbison3 cmake
+           run: choco install -y --force --no-progress asciidoctorj xsltproc docbook-bundle nsis winflexbison3 cmake
          - name: Install strawberryperl
            uses: shogo82148/actions-setup-perl@v1
            with:
@@ -80,7 +80,7 @@ jobs:
               mv build/packaging/nsis/*exe v2g-artifact/
          - name: Move plugin dll
            run: |
-              mv build/run/RelWithDebInfo/plugins/4.0/epan/v2gexi.dll v2g-artifact/v2gexi.dll
+              mv build/run/RelWithDebInfo/plugins/4.2/epan/v2gexi.dll v2g-artifact/v2gexi.dll
          - name: Copy dissector lua
            run: |
               cp plugins/epan/v2g/dissector/v2g.lua v2g-artifact/v2g.lua

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ placed in this directory.
 
 For Linux
 - copy v2g.lua to `~/.local/lib/wireshark/plugins`
-- copy v2gexi.so to `~/.local/lib/wireshark/plugins/4.0/epan`
+- copy v2gexi.so to `~/.local/lib/wireshark/plugins/4.2/epan`
 
 For Mac
 - copy v2g.lua to `~/.local/lib/wireshark/plugins`
-- copy v2gexi.so to `~/.local/lib/wireshark/plugins/4-0/epan`
+- copy v2gexi.so to `~/.local/lib/wireshark/plugins/4-2/epan`
 
 ### Windows
 
@@ -49,7 +49,7 @@ and this can have a bit of a different layout to ensure the dll will
 load on windows.
 
 - copy the v2g.lua to `%APPDATA%/Wireshark/plugins`
-- copy the v2gexi.dll to `%APPDATA%/Wireshark/plugins/4.0/epan`
+- copy the v2gexi.dll to `%APPDATA%/Wireshark/plugins/4.2/epan`
 
 __NOTE__: The global plugin folder can also be used in the "Wireshark"
 directory under `Program Files` where Wireshark.exe is located. The
@@ -88,7 +88,7 @@ To build and install the plugin as part of Wireshark (ie. permenant)
     ```
     git clone https://gitlab.com/wireshark/wireshark
     cd wireshark
-    git checkout release-4.0
+    git checkout release-4.2
     ```
 
 2) Copy the V2G plugin to a new `plugins/epan/v2g` directory
@@ -98,7 +98,7 @@ To build and install the plugin as part of Wireshark (ie. permenant)
 
 3) Patch the cmake in wireshark to include the v2g plugin
     ```
-    git apply plugins/epan/v2g/extern/wireshark-release-4.0.patch
+    git apply plugins/epan/v2g/extern/wireshark-release-4.2.patch
     ```
 
 4) Perform a new wireshark build with the v2g plugin
@@ -122,7 +122,7 @@ the build steps.
     ```
     git clone https://gitlab.com/wireshark/wireshark
     cd wireshark
-    git checkout release-4.0
+    git checkout release-4.2
     ```
 
 2) Copy the V2G plugin to a new `plugins/epan/v2g` directory
@@ -132,7 +132,7 @@ the build steps.
 
 3) Patch the cmake in wireshark to include the v2g plugin
     ```
-    git apply plugins/epan/v2g/extern/wireshark-release-4.0.patch
+    git apply plugins/epan/v2g/extern/wireshark-release-4.2.patch
     ```
 
 4) Use the wireshark tools script to setup brew to build
@@ -167,7 +167,7 @@ setup.
 
 3) Patch the wireshark build system to include the plugin
     ```
-    git apply plugins/epan/v2g/extern/wireshark-release-4.0.patch
+    git apply plugins/epan/v2g/extern/wireshark-release-4.2.patch
     ```
 
 4) Perform the full build including the plugin

--- a/extern/wireshark-release-4.2.patch
+++ b/extern/wireshark-release-4.2.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 271fee968f..27638791fe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1640,6 +1640,7 @@ if(ENABLE_PLUGINS)
+ 		plugins/epan/stats_tree
+ 		plugins/epan/transum
+ 		plugins/epan/unistim
++		plugins/epan/v2g
+ 		plugins/epan/wimax
+ 		plugins/epan/wimaxasncp
+ 		plugins/epan/wimaxmacphy
+diff --git a/packaging/nsis/wireshark.nsi b/packaging/nsis/wireshark.nsi
+index 6c081286b3..1311a10fba 100644
+--- a/packaging/nsis/wireshark.nsi
++++ b/packaging/nsis/wireshark.nsi
+@@ -1015,6 +1015,8 @@ File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\irda.dll"
+ File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\opcua.dll"
+ File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\profinet.dll"
+ File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\unistim.dll"
++File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\v2gexi.dll"
++File "${TOP_SRC_DIR}\plugins\epan\v2g\dissector\v2g.lua"
+ File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\wimax.dll"
+ File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\wimaxasncp.dll"
+ File "${STAGING_DIR}\plugins\${MAJOR_VERSION}.${MINOR_VERSION}\epan\wimaxmacphy.dll"


### PR DESCRIPTION
The build dependencies and github workflows have evolved, so update the workflows to use current release ofr wireshark at this time which is 4.2

Fixes #51