### PR TITLE
Fixes ISO 15118-20 dissector issues to decode non-PnC DC and common messages

### DIFF
--- a/extern/dependencies.cmake
+++ b/extern/dependencies.cmake
@@ -13,6 +13,7 @@ FetchContent_Declare(libcbv2g
     GIT_SHALLOW ON
     PATCH_COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-to-build-standalone.patch
           COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-add-static-and-position-independent-code.patch
+          COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-fix-iso20-loop-grammars.patch
     CMAKE_ARGS -DCB_V2G_BUILD_TESTS:BOOL=OFF
 )
 

--- a/extern/libcbv2g-fix-iso20-loop-grammars.patch
+++ b/extern/libcbv2g-fix-iso20-loop-grammars.patch
@@ -1,0 +1,124 @@
+diff --git a/lib/cbv2g/iso_20/iso20_CommonMessages_Decoder.c b/lib/cbv2g/iso_20/iso20_CommonMessages_Decoder.c
+index 2394a09..13114a7 100644
+--- a/lib/cbv2g/iso_20/iso20_CommonMessages_Decoder.c
++++ b/lib/cbv2g/iso_20/iso20_CommonMessages_Decoder.c
+@@ -3610,7 +3610,7 @@ static int decode_iso20_PowerScheduleEntryListType(exi_bitstream_t* stream, stru
+                     {
+                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
+                     }
+-                    grammar_id = 3;
++                    grammar_id = 68;
+                     break;
+                 case 1:
+                     // Event: END Element; next=3
+@@ -4786,7 +4786,7 @@ static int decode_iso20_EVPowerScheduleEntryListType(exi_bitstream_t* stream, st
+                     {
+                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
+                     }
+-                    grammar_id = 3;
++                    grammar_id = 93;
+                     break;
+                 case 1:
+                     // Event: END Element; next=3
+@@ -5073,7 +5073,7 @@ static int decode_iso20_EVPriceRuleStackListType(exi_bitstream_t* stream, struct
+                     {
+                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
+                     }
+-                    grammar_id = 3;
++                    grammar_id = 99;
+                     break;
+                 case 1:
+                     // Event: END Element; next=3
+@@ -7191,7 +7191,7 @@ static int decode_iso20_PriceLevelScheduleEntryListType(exi_bitstream_t* stream,
+                     {
+                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
+                     }
+-                    grammar_id = 3;
++                    grammar_id = 132;
+                     break;
+                 case 1:
+                     // Event: END Element; next=3
+@@ -7735,7 +7735,7 @@ static int decode_iso20_PriceRuleStackListType(exi_bitstream_t* stream, struct i
+                     {
+                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
+                     }
+-                    grammar_id = 3;
++                    grammar_id = 146;
+                     break;
+                 case 1:
+                     // Event: END Element; next=3
+@@ -9110,7 +9110,7 @@ static int decode_iso20_SupportedProvidersListType(exi_bitstream_t* stream, stru
+                         {
+                             if (eventCode == 0)
+                             {
+-                                grammar_id = 3;
++                                grammar_id = 180;
+                             }
+                             else
+                             {
+@@ -9254,14 +9254,19 @@ static int decode_iso20_ContractCertificateChainType(exi_bitstream_t* stream, st
+ // Element: definition=complex; name={urn:iso:std:iso:15118:-20:CommonMessages}Dynamic_EVPPTControlMode; type={urn:iso:std:iso:15118:-20:CommonMessages}Dynamic_EVPPTControlModeType; base type=; content type=empty;
+ //          abstract=False; final=False;
+ static int decode_iso20_Dynamic_EVPPTControlModeType(exi_bitstream_t* stream, struct iso20_Dynamic_EVPPTControlModeType* Dynamic_EVPPTControlModeType) {
+-    // Element has no particles, so the function just decodes END Element
+-    (void)Dynamic_EVPPTControlModeType;
+     uint32_t eventCode;
++    int error;
+ 
+-    int error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
++    init_iso20_Dynamic_EVPPTControlModeType(Dynamic_EVPPTControlModeType);
++
++    error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+     if (error == 0)
+     {
+-        if (eventCode != 0)
++        if (eventCode == 0)
++        {
++            // END Element
++        }
++        else
+         {
+             error = EXI_ERROR__UNKNOWN_EVENT_CODE;
+         }
+@@ -12512,7 +12517,7 @@ static int decode_iso20_EVPowerProfileEntryListType(exi_bitstream_t* stream, str
+                 switch(eventCode)
+                 {
+                 case 0:
+-                    // Event: LOOP (EVPowerProfileEntry, PowerScheduleEntryType (PowerScheduleEntryType)); next=3
++                    // Event: LOOP (EVPowerProfileEntry, PowerScheduleEntryType (PowerScheduleEntryType)); next=265
+                     // decode: element array
+                     if (EVPowerProfileEntryListType->EVPowerProfileEntry.arrayLen < iso20_PowerScheduleEntryType_2048_ARRAY_SIZE)
+                     {
+@@ -12522,7 +12527,7 @@ static int decode_iso20_EVPowerProfileEntryListType(exi_bitstream_t* stream, str
+                     {
+                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
+                     }
+-                    grammar_id = 3;
++                    grammar_id = 265;
+                     break;
+                 case 1:
+                     // Event: END Element; next=3
+@@ -12569,14 +12574,19 @@ static int decode_iso20_EVPowerProfileEntryListType(exi_bitstream_t* stream, str
+ // Element: definition=complex; name={urn:iso:std:iso:15118:-20:CommonMessages}Dynamic_SMDTControlMode; type={urn:iso:std:iso:15118:-20:CommonMessages}Dynamic_SMDTControlModeType; base type=; content type=empty;
+ //          abstract=False; final=False;
+ static int decode_iso20_Dynamic_SMDTControlModeType(exi_bitstream_t* stream, struct iso20_Dynamic_SMDTControlModeType* Dynamic_SMDTControlModeType) {
+-    // Element has no particles, so the function just decodes END Element
+-    (void)Dynamic_SMDTControlModeType;
+     uint32_t eventCode;
++    int error;
+ 
+-    int error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
++    init_iso20_Dynamic_SMDTControlModeType(Dynamic_SMDTControlModeType);
++
++    error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+     if (error == 0)
+     {
+-        if (eventCode != 0)
++        if (eventCode == 0)
++        {
++            // END Element
++        }
++        else
+         {
+             error = EXI_ERROR__UNKNOWN_EVENT_CODE;
+         }

--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -4691,10 +4691,12 @@ dissect_iso20_ScheduleExchangeResType(
 		tvb, 0, 0, res->EVSEProcessing);
 	proto_item_set_generated(it);
 
-	it = proto_tree_add_uint(subtree,
-		hf_struct_iso20_ScheduleExchangeResType_GoToPause,
-		tvb, 0, 0, res->GoToPause);
-	proto_item_set_generated(it);
+	if (res->GoToPause_isUsed) {
+		it = proto_tree_add_boolean(subtree,
+			hf_struct_iso20_ScheduleExchangeResType_GoToPause,
+			tvb, 0, 0, res->GoToPause);
+		proto_item_set_generated(it);
+	}
 
 	if (res->Dynamic_SEResControlMode_isUsed) {
 		dissect_iso20_Dynamic_SEResControlModeType(
@@ -6073,8 +6075,8 @@ proto_register_v2giso20(void)
 		{ &hf_struct_iso20_ScheduleExchangeResType_GoToPause,
 		  { "GoToPause",
 		    "v2giso20.struct.scheduleexchangeres.gotopause",
-		    FT_UINT16, BASE_DEC,
-		    VALS(v2giso20_enum_iso20_processingType_names),
+		    FT_BOOLEAN, BASE_NONE,
+		    NULL,
 		    0x0, NULL, HFILL }
 		},
 

--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -6698,6 +6698,16 @@ proto_register_v2giso20(void)
 		    VALS(v2giso20_enum_iso20_chargingSessionType_names),
 		    0x0, NULL, HFILL }
 		},
+		{ &hf_struct_iso20_SessionStopReqType_EVTerminationCode,
+		  { "EVTerminationCode",
+		    "v2giso20.struct.sessionstopreq.evterminationcode",
+		    FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_SessionStopReqType_EVTerminationExplanation,
+		  { "EVTerminationExplanation",
+		    "v2giso20.struct.sessionstopreq.evterminationexplanation",
+		    FT_STRING, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
 		/* struct iso20_SessionStopResType */
 		{ &hf_struct_iso20_SessionStopResType_ResponseCode,
 		  { "ResponseCode",

--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -2459,13 +2459,15 @@ dissect_iso20_SupportedProvidersListType(
 static void
 dissect_iso20_EIM_AReqAuthorizationModeType(
 	const struct iso20_EIM_AReqAuthorizationModeType *node _U_,
-	tvbuff_t *tvb _U_,
+	tvbuff_t *tvb,
 	packet_info *pinfo _U_,
-	proto_tree *tree _U_,
-	gint idx _U_,
-	const char *subtree_name _U_)
+	proto_tree *tree,
+	gint idx,
+	const char *subtree_name)
 {
-	/* unused */
+	/* EIM_AReqAuthorizationModeType has no fields (content type=empty),
+	 * but we show a subtree so the presence of EIM mode is visible */
+	proto_tree_add_subtree(tree, tvb, 0, 0, idx, NULL, subtree_name);
 	return;
 }
 
@@ -2511,13 +2513,15 @@ dissect_iso20_PnC_AReqAuthorizationModeType(
 static void
 dissect_iso20_EIM_ASResAuthorizationModeType(
 	const struct iso20_EIM_ASResAuthorizationModeType *node _U_,
-	tvbuff_t *tvb _U_,
+	tvbuff_t *tvb,
 	packet_info *pinfo _U_,
-	proto_tree *tree _U_,
-	gint idx _U_,
-	const char *subtree_name _U_)
+	proto_tree *tree,
+	gint idx,
+	const char *subtree_name)
 {
-	/* unused */
+	/* EIM_ASResAuthorizationModeType has no fields (content type=empty),
+	 * but we show a subtree so the presence of EIM mode is visible */
+	proto_tree_add_subtree(tree, tvb, 0, 0, idx, NULL, subtree_name);
 	return;
 }
 
@@ -5701,7 +5705,7 @@ proto_register_v2giso20(void)
 		    0x0, NULL, HFILL }
 		},
 		{ &hf_struct_iso20_AuthorizationSetupResType_Authorization,
-		  { "ResponseCode",
+		  { "AuthorizationType",
 		    "v2giso20.struct.authorizationsetupres.authorization",
 		    FT_UINT16, BASE_DEC,
 		    VALS(v2giso20_enum_iso20_authorizationType_names),

--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -4111,13 +4111,15 @@ dissect_iso20_Scheduled_SEResControlModeType(
 static void
 dissect_iso20_Dynamic_EVPPTControlModeType(
 	const struct iso20_Dynamic_EVPPTControlModeType *node _U_,
-	tvbuff_t *tvb _U_,
+	tvbuff_t *tvb,
 	packet_info *pinfo _U_,
-	proto_tree *tree _U_,
-	gint idx _U_,
-	const char *subtree_name _U_)
+	proto_tree *tree,
+	gint idx,
+	const char *subtree_name)
 {
-	/* unused */
+	proto_tree_add_subtree(tree,
+		tvb, 0, 0, idx, NULL, subtree_name);
+
 	return;
 }
 
@@ -6073,11 +6075,11 @@ proto_register_v2giso20(void)
 		},
 
 		{ &hf_struct_iso20_ScheduleExchangeResType_GoToPause,
-		  { "GoToPause",
-		    "v2giso20.struct.scheduleexchangeres.gotopause",
-		    FT_BOOLEAN, BASE_NONE,
-		    NULL,
-		    0x0, NULL, HFILL }
+			{ "GoToPause",
+			"v2giso20.struct.scheduleexchangeres.gotopause",
+			FT_BOOLEAN, 8,
+			NULL,
+			0x0, NULL, HFILL }
 		},
 
 		{ &hf_struct_iso20_Dynamic_SEResControlModeType_DepartureTime,

--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -534,6 +534,63 @@ static const value_string v2giso20_enum_iso20_authorizationType_names[] = {
 	{ 0, NULL }
 };
 
+static const value_string v2giso20_service_id_names[] = {
+	{ 1, "AC" },
+	{ 2, "DC" },
+	{ 3, "WPT" },
+	{ 4, "ACDP_ACD" },
+	{ 5, "AC_BPT" },
+	{ 6, "DC_BPT" },
+	{ 7, "ACDP_BPT" },
+	{ 0, NULL }
+};
+
+/* ISO 15118-20 Table 203/204 - ServiceDetailRes parameter value mappings */
+static const value_string v2giso20_param_dc_connector_names[] = {
+	{ 1, "CORE" },
+	{ 2, "EXTENDED" },
+	{ 3, "DUAL2" },
+	{ 4, "DUAL4" },
+	{ 0, NULL }
+};
+
+static const value_string v2giso20_param_ac_connector_names[] = {
+	{ 1, "SINGLE_PHASE" },
+	{ 2, "THREE_PHASE" },
+	{ 0, NULL }
+};
+
+static const value_string v2giso20_param_controlmode_names[] = {
+	{ 1, "SCHEDULED" },
+	{ 2, "DYNAMIC" },
+	{ 0, NULL }
+};
+
+static const value_string v2giso20_param_mobilityneedsmode_names[] = {
+	{ 1, "EVCC_PROVIDED" },
+	{ 2, "SECC_ALLOWED" },
+	{ 0, NULL }
+};
+
+static const value_string v2giso20_param_pricing_names[] = {
+	{ 0, "NO_PRICING" },
+	{ 1, "STATIC" },
+	{ 2, "DYNAMIC" },
+	{ 0, NULL }
+};
+
+static const value_string v2giso20_param_bptchannel_names[] = {
+	{ 1, "UNIFIED" },
+	{ 2, "SEPARATED" },
+	{ 0, NULL }
+};
+
+static const value_string v2giso20_param_generatormode_names[] = {
+	{ 1, "GRID_FOLLOWING" },
+	{ 2, "GRID_FORMING" },
+	{ 0, NULL }
+};
+
 static const value_string v2giso20_enum_iso20_processingType_names[] = {
 	{ iso20_processingType_Finished, "Finished" },
 	{ iso20_processingType_Ongoing, "Ongoing" },
@@ -1981,7 +2038,8 @@ dissect_iso20_ParameterType(
 	packet_info *pinfo _U_,
 	proto_tree *tree,
 	gint idx,
-	const char *subtree_name)
+	const char *subtree_name,
+	uint16_t service_id)
 {
 	proto_tree *subtree;
 	proto_item *it;
@@ -2015,10 +2073,32 @@ dissect_iso20_ParameterType(
 		proto_item_set_generated(it);
 	}
 	if (parameter->intValue_isUsed) {
+		const char *val_name = NULL;
+		const char *pname = parameter->Name.characters;
+		guint plen = parameter->Name.charactersLen;
+		/* AC service IDs: 1=AC, 5=AC_BPT; DC service IDs: 2=DC, 6=DC_BPT, 3=WPT, 4=ACDP_ACD, 7=ACDP_BPT */
+		gboolean is_ac = (service_id == 1 || service_id == 5);
 		it = proto_tree_add_int(subtree,
 			hf_struct_iso20_ParameterType_intValue,
 			tvb, 0, 0, parameter->intValue);
 		proto_item_set_generated(it);
+		if (strncmp(pname, "Connector", plen) == 0)
+			val_name = val_to_str_const(parameter->intValue,
+				is_ac ? v2giso20_param_ac_connector_names
+				      : v2giso20_param_dc_connector_names,
+				"Unknown");
+		else if (strncmp(pname, "ControlMode", plen) == 0)
+			val_name = val_to_str_const(parameter->intValue, v2giso20_param_controlmode_names, "Unknown");
+		else if (strncmp(pname, "MobilityNeedsMode", plen) == 0)
+			val_name = val_to_str_const(parameter->intValue, v2giso20_param_mobilityneedsmode_names, "Unknown");
+		else if (strncmp(pname, "Pricing", plen) == 0)
+			val_name = val_to_str_const(parameter->intValue, v2giso20_param_pricing_names, "Unknown");
+		else if (strncmp(pname, "BPTChannel", plen) == 0)
+			val_name = val_to_str_const(parameter->intValue, v2giso20_param_bptchannel_names, "Unknown");
+		else if (strncmp(pname, "GeneratorMode", plen) == 0)
+			val_name = val_to_str_const(parameter->intValue, v2giso20_param_generatormode_names, "Unknown");
+		if (val_name)
+			proto_item_set_text(it, "intValue: %s (%d)", val_name, parameter->intValue);
 	}
 	if (parameter->rationalNumber_isUsed) {
 		dissect_iso20_RationalNumberType(&parameter->rationalNumber,
@@ -2046,7 +2126,8 @@ dissect_iso20_ParameterSetType(
 	packet_info *pinfo _U_,
 	proto_tree *tree,
 	gint idx,
-	const char *subtree_name)
+	const char *subtree_name,
+	uint16_t service_id)
 {
 	unsigned int i;
 	proto_tree *subtree;
@@ -2070,7 +2151,8 @@ dissect_iso20_ParameterSetType(
 		dissect_iso20_ParameterType(
 			&node->Parameter.array[i],
 			tvb, pinfo, parameter_tree,
-			ett_struct_iso20_ParameterType, index);
+			ett_struct_iso20_ParameterType, index,
+			service_id);
 	}
 
 	return;
@@ -2625,7 +2707,8 @@ dissect_iso20_ServiceParameterListType(
 	packet_info *pinfo _U_,
 	proto_tree *tree,
 	gint idx,
-	const char *subtree_name)
+	const char *subtree_name,
+	uint16_t service_id)
 {
 	unsigned int i;
 	proto_tree *subtree;
@@ -2635,7 +2718,7 @@ dissect_iso20_ServiceParameterListType(
 		tvb, 0, 0, idx, NULL, subtree_name);
 
 	parameterset_tree = proto_tree_add_subtree(subtree,
-		tvb, 0, 0, ett_v2giso20_array, NULL, "Service");
+		tvb, 0, 0, ett_v2giso20_array, NULL, "ParameterSet");
 	for (i = 0; i < node->ParameterSet.arrayLen; i++) {
 		char index[sizeof("[65536]")];
 
@@ -2644,7 +2727,7 @@ dissect_iso20_ServiceParameterListType(
 			&node->ParameterSet.array[i],
 			tvb, pinfo, parameterset_tree,
 			ett_struct_iso20_ParameterSetType,
-			index);
+			index, service_id);
 	}
 
 	return;
@@ -4469,7 +4552,7 @@ dissect_iso20_ServiceDetailResType(
 		&res->ServiceParameterList,
 		tvb, pinfo, subtree,
 		ett_struct_iso20_ServiceParameterListType,
-		"ServiceParameterList");
+		"ServiceParameterList", res->ServiceID);
 
 	return;
 }
@@ -5800,13 +5883,15 @@ proto_register_v2giso20(void)
 		{ &hf_struct_iso20_ServiceIDListType_ServiceID,
 		  { "ServiceID",
 		    "vgiso20.struct.serviceidlist.serviceid",
-		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_UINT16, BASE_DEC,
+		    VALS(v2giso20_service_id_names), 0x0, NULL, HFILL }
 		},
 
 		/* struct iso20_ServiceType */
 		{ &hf_struct_iso20_ServiceType_ServiceID,
 		  { "ServiceID", "vgiso20.struct.service.serviceid",
-		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_UINT16, BASE_DEC,
+		    VALS(v2giso20_service_id_names), 0x0, NULL, HFILL }
 		},
 		{ &hf_struct_iso20_ServiceType_FreeService,
 		  { "FreeService", "vgiso20.struct.service.freeservice",
@@ -5817,7 +5902,8 @@ proto_register_v2giso20(void)
 		{ &hf_struct_iso20_ServiceDetailReqType_ServiceID,
 		  { "ServiceID",
 		    "v2giso20.struct.servicedetailreq.serviceid",
-		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_UINT16, BASE_DEC,
+		    VALS(v2giso20_service_id_names), 0x0, NULL, HFILL }
 		},
 		/* struct iso20_ServiceDetailResType */
 		{ &hf_struct_iso20_ServiceDetailResType_ResponseCode,
@@ -5830,7 +5916,8 @@ proto_register_v2giso20(void)
 		{ &hf_struct_iso20_ServiceDetailResType_ServiceID,
 		  { "ServiceID",
 		    "v2giso20.struct.servicedetailres.serviceid",
-		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_UINT16, BASE_DEC,
+		    VALS(v2giso20_service_id_names), 0x0, NULL, HFILL }
 		},
 
 		/* struct iso20_ParameterSetType */
@@ -6395,7 +6482,8 @@ proto_register_v2giso20(void)
 		/* struct iso20_SelectedServiceType */
 		{ &hf_struct_iso20_SelectedServiceType_ServiceID,
 		  { "ServiceID", "vgiso20.struct.selectedservice.serviceid",
-		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_UINT16, BASE_DEC,
+		    VALS(v2giso20_service_id_names), 0x0, NULL, HFILL }
 		},
 		{ &hf_struct_iso20_SelectedServiceType_ParameterSetID,
 		  { "ParameterSetID",

--- a/src/packet-v2giso20_dc.c
+++ b/src/packet-v2giso20_dc.c
@@ -101,6 +101,35 @@ static int hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEPowerLimitAchieved = -1;
 static int hf_struct_iso20_dc_DC_ChargeLoopResType_EVSECurrentLimitAchieved = -1;
 static int hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEVoltageLimitAchieved = -1;
 
+/* DisplayParametersType */
+static int hf_struct_iso20_dc_DisplayParametersType_PresentSOC = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_MinimumSOC = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_TargetSOC = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_MaximumSOC = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToMinimumSOC = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToTargetSOC = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToMaximumSOC = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_ChargingComplete = -1;
+static int hf_struct_iso20_dc_DisplayParametersType_InletHot = -1;
+
+/* Dynamic_DC_CLReqControlModeType */
+static int hf_struct_iso20_dc_Dynamic_DC_CLReqControlModeType_DepartureTime = -1;
+
+/* Dynamic_DC_CLResControlModeType */
+static int hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_DepartureTime = -1;
+static int hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_MinimumSOC = -1;
+static int hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_TargetSOC = -1;
+static int hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_AckMaxDelay = -1;
+
+/* BPT_Dynamic_DC_CLReqControlModeType */
+static int hf_struct_iso20_dc_BPT_Dynamic_DC_CLReqControlModeType_DepartureTime = -1;
+
+/* BPT_Dynamic_DC_CLResControlModeType */
+static int hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_DepartureTime = -1;
+static int hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_MinimumSOC = -1;
+static int hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_TargetSOC = -1;
+static int hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_AckMaxDelay = -1;
+
 /* DC_WeldingDetection */
 static int hf_struct_iso20_dc_DC_WeldingDetectionReqType_EVProcessing = -1;
 static int hf_struct_iso20_dc_DC_WeldingDetectionResType_ResponseCode = -1;
@@ -1779,7 +1808,43 @@ dissect_iso20_dc_Dynamic_DC_CLReqControlModeType(
 	gint idx _U_,
 	const char *subtree_name _U_)
 {
-	/* TODO */
+	proto_tree *subtree;
+	proto_item *it;
+
+	subtree = proto_tree_add_subtree(tree,
+		tvb, 0, 0, idx, NULL, subtree_name);
+
+	if (node->DepartureTime_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_Dynamic_DC_CLReqControlModeType_DepartureTime,
+			tvb, 0, 0, node->DepartureTime);
+		proto_item_set_generated(it);
+	}
+	dissect_iso20_dc_RationalNumberType(&node->EVTargetEnergyRequest,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVTargetEnergyRequest");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumEnergyRequest,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumEnergyRequest");
+	dissect_iso20_dc_RationalNumberType(&node->EVMinimumEnergyRequest,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMinimumEnergyRequest");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVMinimumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMinimumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumChargeCurrent,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumChargeCurrent");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumVoltage,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumVoltage");
+	dissect_iso20_dc_RationalNumberType(&node->EVMinimumVoltage,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMinimumVoltage");
+
 	return;
 }
 
@@ -1792,7 +1857,49 @@ dissect_iso20_dc_Dynamic_DC_CLResControlModeType(
 	gint idx _U_,
 	const char *subtree_name _U_)
 {
-	/* TODO */
+	proto_tree *subtree;
+	proto_item *it;
+
+	subtree = proto_tree_add_subtree(tree,
+		tvb, 0, 0, idx, NULL, subtree_name);
+
+	if (node->DepartureTime_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_DepartureTime,
+			tvb, 0, 0, node->DepartureTime);
+		proto_item_set_generated(it);
+	}
+	if (node->MinimumSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_MinimumSOC,
+			tvb, 0, 0, node->MinimumSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->TargetSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_TargetSOC,
+			tvb, 0, 0, node->TargetSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->AckMaxDelay_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_AckMaxDelay,
+			tvb, 0, 0, node->AckMaxDelay);
+		proto_item_set_generated(it);
+	}
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMinimumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMinimumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumChargeCurrent,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumChargeCurrent");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumVoltage,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumVoltage");
+
 	return;
 }
 
@@ -1805,7 +1912,62 @@ dissect_iso20_dc_BPT_Dynamic_DC_CLReqControlModeType(
 	gint idx _U_,
 	const char *subtree_name _U_)
 {
-	/* TODO */
+	proto_tree *subtree;
+	proto_item *it;
+
+	subtree = proto_tree_add_subtree(tree,
+		tvb, 0, 0, idx, NULL, subtree_name);
+
+	if (node->DepartureTime_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_BPT_Dynamic_DC_CLReqControlModeType_DepartureTime,
+			tvb, 0, 0, node->DepartureTime);
+		proto_item_set_generated(it);
+	}
+	dissect_iso20_dc_RationalNumberType(&node->EVTargetEnergyRequest,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVTargetEnergyRequest");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumEnergyRequest,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumEnergyRequest");
+	dissect_iso20_dc_RationalNumberType(&node->EVMinimumEnergyRequest,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMinimumEnergyRequest");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVMinimumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMinimumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumChargeCurrent,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumChargeCurrent");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumVoltage,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumVoltage");
+	dissect_iso20_dc_RationalNumberType(&node->EVMinimumVoltage,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMinimumVoltage");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumDischargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumDischargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVMinimumDischargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMinimumDischargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVMaximumDischargeCurrent,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVMaximumDischargeCurrent");
+	if (node->EVMaximumV2XEnergyRequest_isUsed) {
+		dissect_iso20_dc_RationalNumberType(&node->EVMaximumV2XEnergyRequest,
+			tvb, pinfo, subtree,
+			ett_struct_iso20_dc_RationalNumberType, "EVMaximumV2XEnergyRequest");
+	}
+	if (node->EVMinimumV2XEnergyRequest_isUsed) {
+		dissect_iso20_dc_RationalNumberType(&node->EVMinimumV2XEnergyRequest,
+			tvb, pinfo, subtree,
+			ett_struct_iso20_dc_RationalNumberType, "EVMinimumV2XEnergyRequest");
+	}
+
 	return;
 }
 
@@ -1818,7 +1980,61 @@ dissect_iso20_dc_BPT_Dynamic_DC_CLResControlModeType(
 	gint idx _U_,
 	const char *subtree_name _U_)
 {
-	/* TODO */
+	proto_tree *subtree;
+	proto_item *it;
+
+	subtree = proto_tree_add_subtree(tree,
+		tvb, 0, 0, idx, NULL, subtree_name);
+
+	if (node->DepartureTime_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_DepartureTime,
+			tvb, 0, 0, node->DepartureTime);
+		proto_item_set_generated(it);
+	}
+	if (node->MinimumSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_MinimumSOC,
+			tvb, 0, 0, node->MinimumSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->TargetSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_TargetSOC,
+			tvb, 0, 0, node->TargetSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->AckMaxDelay_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_AckMaxDelay,
+			tvb, 0, 0, node->AckMaxDelay);
+		proto_item_set_generated(it);
+	}
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMinimumChargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMinimumChargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumChargeCurrent,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumChargeCurrent");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumVoltage,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumVoltage");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumDischargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumDischargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMinimumDischargePower,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMinimumDischargePower");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMaximumDischargeCurrent,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMaximumDischargeCurrent");
+	dissect_iso20_dc_RationalNumberType(&node->EVSEMinimumVoltage,
+		tvb, pinfo, subtree,
+		ett_struct_iso20_dc_RationalNumberType, "EVSEMinimumVoltage");
+
 	return;
 }
 
@@ -1857,7 +2073,74 @@ dissect_iso20_dc_DisplayParametersType(
 	gint idx _U_,
 	const char *subtree_name _U_)
 {
-	/* TODO */
+	proto_tree *subtree;
+	proto_item *it;
+
+	subtree = proto_tree_add_subtree(tree,
+		tvb, 0, 0, idx, NULL, subtree_name);
+
+	if (node->PresentSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_PresentSOC,
+			tvb, 0, 0, node->PresentSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->MinimumSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_MinimumSOC,
+			tvb, 0, 0, node->MinimumSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->TargetSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_TargetSOC,
+			tvb, 0, 0, node->TargetSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->MaximumSOC_isUsed) {
+		it = proto_tree_add_int(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_MaximumSOC,
+			tvb, 0, 0, node->MaximumSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->RemainingTimeToMinimumSOC_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToMinimumSOC,
+			tvb, 0, 0, node->RemainingTimeToMinimumSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->RemainingTimeToTargetSOC_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToTargetSOC,
+			tvb, 0, 0, node->RemainingTimeToTargetSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->RemainingTimeToMaximumSOC_isUsed) {
+		it = proto_tree_add_uint(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToMaximumSOC,
+			tvb, 0, 0, node->RemainingTimeToMaximumSOC);
+		proto_item_set_generated(it);
+	}
+	if (node->ChargingComplete_isUsed) {
+		it = proto_tree_add_boolean(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_ChargingComplete,
+			tvb, 0, 0, node->ChargingComplete);
+		proto_item_set_generated(it);
+	}
+	if (node->BatteryEnergyCapacity_isUsed) {
+		dissect_iso20_dc_RationalNumberType(
+			&node->BatteryEnergyCapacity,
+			tvb, pinfo, subtree,
+			ett_struct_iso20_dc_RationalNumberType,
+			"BatteryEnergyCapacity");
+	}
+	if (node->InletHot_isUsed) {
+		it = proto_tree_add_boolean(subtree,
+			hf_struct_iso20_dc_DisplayParametersType_InletHot,
+			tvb, 0, 0, node->InletHot);
+		proto_item_set_generated(it);
+	}
+
 	return;
 }
 
@@ -2162,7 +2445,7 @@ dissect_iso20_dc_DC_ChargeLoopReqType(
 			"DisplayParameters");
 	}
 
-	it = proto_tree_add_uint(subtree,
+	it = proto_tree_add_boolean(subtree,
 		hf_struct_iso20_dc_DC_ChargeLoopReqType_MeterInfoRequested,
 		tvb, 0, 0, req->MeterInfoRequested);
 	proto_item_set_generated(it);
@@ -2267,17 +2550,17 @@ dissect_iso20_dc_DC_ChargeLoopResType(
 		ett_struct_iso20_dc_RationalNumberType,
 		"EVSEPresentVoltage");
 
-	it = proto_tree_add_uint(subtree,
+	it = proto_tree_add_boolean(subtree,
 		hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEPowerLimitAchieved,
 		tvb, 0, 0, res->EVSEPowerLimitAchieved);
 	proto_item_set_generated(it);
 
-	it = proto_tree_add_uint(subtree,
+	it = proto_tree_add_boolean(subtree,
 		hf_struct_iso20_dc_DC_ChargeLoopResType_EVSECurrentLimitAchieved,
 		tvb, 0, 0, res->EVSECurrentLimitAchieved);
 	proto_item_set_generated(it);
 
-	it = proto_tree_add_uint(subtree,
+	it = proto_tree_add_boolean(subtree,
 		hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEVoltageLimitAchieved,
 		tvb, 0, 0, res->EVSEVoltageLimitAchieved);
 	proto_item_set_generated(it);
@@ -2844,7 +3127,7 @@ proto_register_v2giso20_dc(void)
 		{ &hf_struct_iso20_dc_DC_ChargeLoopReqType_MeterInfoRequested,
 		  { "MeterInfoRequested",
 		    "v2giso20.dc.struct.dc_chargeloopreq.meterinforequested",
-		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_BOOLEAN, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
 		/* struct iso20_dc_DC_ChargeLoopResType */
 		{ &hf_struct_iso20_dc_DC_ChargeLoopResType_ResponseCode,
@@ -2857,17 +3140,17 @@ proto_register_v2giso20_dc(void)
 		{ &hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEPowerLimitAchieved,
 		  { "EVSEPowerLimitAchieved",
 		    "v2giso20.dc.struct.dc_chargeloopres.evsepowerlimitachieved",
-		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_BOOLEAN, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
 		{ &hf_struct_iso20_dc_DC_ChargeLoopResType_EVSECurrentLimitAchieved,
 		  { "EVSECurrentLimitAchieved",
 		    "v2giso20.dc.struct.dc_chargeloopres.evsecurrentlimitachieved",
-		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_BOOLEAN, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
 		{ &hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEVoltageLimitAchieved,
 		  { "EVSEVoltageLimitAchieved",
 		    "v2giso20.dc.struct.dc_chargeloopres.evsevoltagelimitachieved",
-		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_BOOLEAN, BASE_NONE, NULL, 0x0, NULL, HFILL }
 		},
 
 		/* struct iso20_dc_DC_WeldingDetectionReqType */
@@ -2885,6 +3168,111 @@ proto_register_v2giso20_dc(void)
 		    FT_UINT16, BASE_DEC,
 		    VALS(v2giso20_dc_enum_iso20_dc_responseCodeType_names),
 		    0x0, NULL, HFILL }
+		},
+
+		/* struct iso20_dc_DisplayParametersType */
+		{ &hf_struct_iso20_dc_DisplayParametersType_PresentSOC,
+		  { "PresentSOC",
+		    "v2giso20.dc.struct.displayparameters.presentsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_MinimumSOC,
+		  { "MinimumSOC",
+		    "v2giso20.dc.struct.displayparameters.minimumsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_TargetSOC,
+		  { "TargetSOC",
+		    "v2giso20.dc.struct.displayparameters.targetsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_MaximumSOC,
+		  { "MaximumSOC",
+		    "v2giso20.dc.struct.displayparameters.maximumsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToMinimumSOC,
+		  { "RemainingTimeToMinimumSOC",
+		    "v2giso20.dc.struct.displayparameters.remainingtimetominimumsoc",
+		    FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToTargetSOC,
+		  { "RemainingTimeToTargetSOC",
+		    "v2giso20.dc.struct.displayparameters.remainingtimetotargetsoc",
+		    FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_RemainingTimeToMaximumSOC,
+		  { "RemainingTimeToMaximumSOC",
+		    "v2giso20.dc.struct.displayparameters.remainingtimemaximumsoc",
+		    FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_ChargingComplete,
+		  { "ChargingComplete",
+		    "v2giso20.dc.struct.displayparameters.chargingcomplete",
+		    FT_BOOLEAN, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_DisplayParametersType_InletHot,
+		  { "InletHot",
+		    "v2giso20.dc.struct.displayparameters.inlethot",
+		    FT_BOOLEAN, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+
+		/* struct iso20_dc_Dynamic_DC_CLReqControlModeType */
+		{ &hf_struct_iso20_dc_Dynamic_DC_CLReqControlModeType_DepartureTime,
+		  { "DepartureTime",
+		    "v2giso20.dc.struct.dynamic_dc_clreqcontrolmode.departuretime",
+		    FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+
+		/* struct iso20_dc_Dynamic_DC_CLResControlModeType */
+		{ &hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_DepartureTime,
+		  { "DepartureTime",
+		    "v2giso20.dc.struct.dynamic_dc_clrescontrolmode.departuretime",
+		    FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_MinimumSOC,
+		  { "MinimumSOC",
+		    "v2giso20.dc.struct.dynamic_dc_clrescontrolmode.minimumsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_TargetSOC,
+		  { "TargetSOC",
+		    "v2giso20.dc.struct.dynamic_dc_clrescontrolmode.targetsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_Dynamic_DC_CLResControlModeType_AckMaxDelay,
+		  { "AckMaxDelay",
+		    "v2giso20.dc.struct.dynamic_dc_clrescontrolmode.ackmaxdelay",
+		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+
+		/* struct iso20_dc_BPT_Dynamic_DC_CLReqControlModeType */
+		{ &hf_struct_iso20_dc_BPT_Dynamic_DC_CLReqControlModeType_DepartureTime,
+		  { "DepartureTime",
+		    "v2giso20.dc.struct.bpt_dynamic_dc_clreqcontrolmode.departuretime",
+		    FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+
+		/* struct iso20_dc_BPT_Dynamic_DC_CLResControlModeType */
+		{ &hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_DepartureTime,
+		  { "DepartureTime",
+		    "v2giso20.dc.struct.bpt_dynamic_dc_clrescontrolmode.departuretime",
+		    FT_UINT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_MinimumSOC,
+		  { "MinimumSOC",
+		    "v2giso20.dc.struct.bpt_dynamic_dc_clrescontrolmode.minimumsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_TargetSOC,
+		  { "TargetSOC",
+		    "v2giso20.dc.struct.bpt_dynamic_dc_clrescontrolmode.targetsoc",
+		    FT_INT8, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_BPT_Dynamic_DC_CLResControlModeType_AckMaxDelay,
+		  { "AckMaxDelay",
+		    "v2giso20.dc.struct.bpt_dynamic_dc_clrescontrolmode.ackmaxdelay",
+		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
 		},
 
 		/* struct iso20_dc_DC_CPDReqEnergyTransferModeType */

--- a/src/v2gplugin.c
+++ b/src/v2gplugin.c
@@ -55,12 +55,12 @@ void plugin_register(void)
     proto_register_plugin(&plug_v2giso20);
     static proto_plugin plug_v2giso20_ac;
 
-    plug_v2giso20.register_protoinfo = proto_register_v2giso20_ac;
-    plug_v2giso20.register_handoff = proto_reg_handoff_v2giso20_ac;
+    plug_v2giso20_ac.register_protoinfo = proto_register_v2giso20_ac;
+    plug_v2giso20_ac.register_handoff = proto_reg_handoff_v2giso20_ac;
     proto_register_plugin(&plug_v2giso20_ac);
     static proto_plugin plug_v2giso20_dc;
 
-    plug_v2giso20.register_protoinfo = proto_register_v2giso20_dc;
-    plug_v2giso20.register_handoff = proto_reg_handoff_v2giso20_dc;
+    plug_v2giso20_dc.register_protoinfo = proto_register_v2giso20_dc;
+    plug_v2giso20_dc.register_handoff = proto_reg_handoff_v2giso20_dc;
     proto_register_plugin(&plug_v2giso20_dc);
 }


### PR DESCRIPTION
1.  fix(iso20): correct auth messages
2.  fix(iso20): improve service detail dissector  
3.  fix(iso20): correct scheduleexchange msg dissector
4.  fix(iso20): decode PowerDeliveryReq and PowerDeliveryRes
5.  Fix 7 LOOP grammar transitions in libcbv2g (grammar_id=3 → correct state)
* Add patch file extern/libcbv2g-fix-iso20-loop-grammars.patch
* fix(iso20): implement DC ChargeLoop dissectors
* Implement DisplayParametersType, Dynamic/BPT_Dynamic CLReq/CLRes control modes
* Fix boolean field types for MeterInfoRequested, EVSEPowerLimitAchieved, etc.
* fix(iso20): register missing hf fields for SessionStopReq
* EVTerminationCode and EVTerminationExplanation were causing a dissector crash

Tested against: happy_path_nonPnC.pcap (ISO 15118-20 DC charging session)

Pcap file for non PnC is attached in the ticket. All the messages are decoded correctly.
verified the messages with the message structure on vector.