### PR TITLE
fix(iso20): prevent BER dissector from overwriting protocol columns

### DIFF
--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -1339,7 +1339,11 @@ dissect_iso20_X509DataType(
 				child, 0, tvb_reported_length(child),
 				ett_v2giso20_asn1, NULL,
 				"X509Certificate ASN1");
+			col_set_writable(pinfo->cinfo, COL_PROTOCOL, FALSE);
+			col_set_writable(pinfo->cinfo, COL_INFO, FALSE);
 			call_dissector(v2gber_handle, child, pinfo, asn1_tree);
+			col_set_writable(pinfo->cinfo, COL_PROTOCOL, TRUE);
+			col_set_writable(pinfo->cinfo, COL_INFO, TRUE);
 		}
 	}
 
@@ -2233,7 +2237,11 @@ dissect_iso20_SubCertificatesType(
 			asn1_tree = proto_tree_add_subtree(certificate_i_tree,
 				child, 0, tvb_reported_length(child),
 				ett_v2giso20_asn1, NULL, "Certificate ASN1");
+			col_set_writable(pinfo->cinfo, COL_PROTOCOL, FALSE);
+			col_set_writable(pinfo->cinfo, COL_INFO, FALSE);
 			call_dissector(v2gber_handle, child, pinfo, asn1_tree);
+			col_set_writable(pinfo->cinfo, COL_PROTOCOL, TRUE);
+			col_set_writable(pinfo->cinfo, COL_INFO, TRUE);
 		}
 	}
 
@@ -2274,7 +2282,11 @@ dissect_iso20_CertificateChainType(
 		asn1_tree = proto_tree_add_subtree(subtree,
 			child, 0, tvb_reported_length(child),
 			ett_v2giso20_asn1, NULL, "Certificate ASN1");
+		col_set_writable(pinfo->cinfo, COL_PROTOCOL, FALSE);
+		col_set_writable(pinfo->cinfo, COL_INFO, FALSE);
 		call_dissector(v2gber_handle, child, pinfo, asn1_tree);
+		col_set_writable(pinfo->cinfo, COL_PROTOCOL, TRUE);
+		col_set_writable(pinfo->cinfo, COL_INFO, TRUE);
 	}
 
 	if (node->SubCertificates_isUsed) {
@@ -2322,7 +2334,11 @@ dissect_iso20_ContractCertificateChainType(
 		asn1_tree = proto_tree_add_subtree(subtree,
 			child, 0, tvb_reported_length(child),
 			ett_v2giso20_asn1, NULL, "Certificate ASN1");
+		col_set_writable(pinfo->cinfo, COL_PROTOCOL, FALSE);
+		col_set_writable(pinfo->cinfo, COL_INFO, FALSE);
 		call_dissector(v2gber_handle, child, pinfo, asn1_tree);
+		col_set_writable(pinfo->cinfo, COL_PROTOCOL, TRUE);
+		col_set_writable(pinfo->cinfo, COL_INFO, TRUE);
 	}
 
 	dissect_iso20_SubCertificatesType(
@@ -2375,7 +2391,11 @@ dissect_iso20_SignedCertificateChainType(
 		asn1_tree = proto_tree_add_subtree(subtree,
 			child, 0, tvb_reported_length(child),
 			ett_v2giso20_asn1, NULL, "Certificate ASN1");
+		col_set_writable(pinfo->cinfo, COL_PROTOCOL, FALSE);
+		col_set_writable(pinfo->cinfo, COL_INFO, FALSE);
 		call_dissector(v2gber_handle, child, pinfo, asn1_tree);
+		col_set_writable(pinfo->cinfo, COL_PROTOCOL, TRUE);
+		col_set_writable(pinfo->cinfo, COL_INFO, TRUE);
 	}
 
 	if (node->SubCertificates_isUsed) {

--- a/src/packet-v2giso20_dc.c
+++ b/src/packet-v2giso20_dc.c
@@ -101,6 +101,10 @@ static int hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEPowerLimitAchieved = -1;
 static int hf_struct_iso20_dc_DC_ChargeLoopResType_EVSECurrentLimitAchieved = -1;
 static int hf_struct_iso20_dc_DC_ChargeLoopResType_EVSEVoltageLimitAchieved = -1;
 
+/* EVSEStatusType */
+static int hf_struct_iso20_dc_EVSEStatusType_NotificationMaxDelay = -1;
+static int hf_struct_iso20_dc_EVSEStatusType_EVSENotification = -1;
+
 /* DisplayParametersType */
 static int hf_struct_iso20_dc_DisplayParametersType_PresentSOC = -1;
 static int hf_struct_iso20_dc_DisplayParametersType_MinimumSOC = -1;
@@ -292,6 +296,16 @@ static const value_string v2giso20_dc_enum_iso20_dc_processingType_names[] = {
 	{ iso20_dc_processingType_Ongoing, "Ongoing" },
 	{ iso20_dc_processingType_Ongoing_WaitingForCustomerInteraction,
 	  "WaitingForCustomerInteraction" },
+	{ 0, NULL }
+};
+
+static const value_string v2giso20_dc_enum_iso20_dc_evseNotificationType_names[] = {
+	{ iso20_dc_evseNotificationType_Pause, "Pause" },
+	{ iso20_dc_evseNotificationType_ExitStandby, "ExitStandby" },
+	{ iso20_dc_evseNotificationType_Terminate, "Terminate" },
+	{ iso20_dc_evseNotificationType_ScheduleRenegotiation, "ScheduleRenegotiation" },
+	{ iso20_dc_evseNotificationType_ServiceRenegotiation, "ServiceRenegotiation" },
+	{ iso20_dc_evseNotificationType_MeteringConfirmation, "MeteringConfirmation" },
 	{ 0, NULL }
 };
 
@@ -2153,7 +2167,22 @@ dissect_iso20_dc_EVSEStatusType(
 	gint idx _U_,
 	const char *subtree_name _U_)
 {
-	/* TODO */
+	proto_tree *subtree;
+	proto_item *it;
+
+	subtree = proto_tree_add_subtree(tree,
+		tvb, 0, 0, idx, NULL, subtree_name);
+
+	it = proto_tree_add_uint(subtree,
+		hf_struct_iso20_dc_EVSEStatusType_NotificationMaxDelay,
+		tvb, 0, 0, node->NotificationMaxDelay);
+	proto_item_set_generated(it);
+
+	it = proto_tree_add_uint(subtree,
+		hf_struct_iso20_dc_EVSEStatusType_EVSENotification,
+		tvb, 0, 0, node->EVSENotification);
+	proto_item_set_generated(it);
+
 	return;
 }
 
@@ -3215,6 +3244,20 @@ proto_register_v2giso20_dc(void)
 		  { "InletHot",
 		    "v2giso20.dc.struct.displayparameters.inlethot",
 		    FT_BOOLEAN, BASE_NONE, NULL, 0x0, NULL, HFILL }
+		},
+
+		/* struct iso20_dc_EVSEStatusType */
+		{ &hf_struct_iso20_dc_EVSEStatusType_NotificationMaxDelay,
+		  { "NotificationMaxDelay",
+		    "v2giso20.dc.struct.evsestatustype.notificationmaxdelay",
+		    FT_UINT16, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		},
+		{ &hf_struct_iso20_dc_EVSEStatusType_EVSENotification,
+		  { "EVSENotification",
+		    "v2giso20.dc.struct.evsestatustype.evsenotification",
+		    FT_UINT16, BASE_DEC,
+		    VALS(v2giso20_dc_enum_iso20_dc_evseNotificationType_names),
+		    0x0, NULL, HFILL }
 		},
 
 		/* struct iso20_dc_Dynamic_DC_CLReqControlModeType */


### PR DESCRIPTION
When decoding X.509 certificates in PnC messages (AuthorizationReq, etc.), the BER sub-dissector was overwriting COL_PROTOCOL to "BER" and COL_INFO to "Unknown BER". Fix by setting columns non-writable before calling into the BER dissector and restoring after.

[[PLAT-18268](https://chargepoint.atlassian.net/browse/PLAT-18268)]

Able to decode AuthorizationReq name correctly
<img width="1779" height="183" alt="Screenshot from 2026-06-15 12-27-30" src="https://github.com/user-attachments/assets/8c1f79bf-ab14-4d39-87fd-6ec3a13e914b" />

Decoding the EVSEStatusType in DC_ChargeLoopRes
<img width="1426" height="463" alt="Screenshot from 2026-06-18 12-29-50" src="https://github.com/user-attachments/assets/03665b87-8917-4b87-b539-3d3cdc130370" />

[PLAT-18268]: https://chargepoint.atlassian.net/browse/PLAT-18268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ