### PR TITLE
fix(iso20_dc): certificateinstallation exi decode

### DIFF
--- a/extern/dependencies.cmake
+++ b/extern/dependencies.cmake
@@ -4,16 +4,13 @@ include(FetchContent)
 #
 # Use the libcbv2g project as part of the dissector
 #
-set(libcbv2g_VERSION 0.2.0)
 set(LIBCBV2G_PATCH_COMMAND patch -p1)
 
 FetchContent_Declare(libcbv2g
     GIT_REPOSITORY https://github.com/EVerest/libcbv2g.git
-    GIT_TAG v${libcbv2g_VERSION}
-    GIT_SHALLOW ON
-    PATCH_COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-to-build-standalone.patch
-          COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-add-static-and-position-independent-code.patch
-          COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-fix-iso20-loop-grammars.patch
+    GIT_TAG 03350be048b35b179905129005a97144a4bdcf93
+    PATCH_COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-add-static-and-position-independent-code.patch
+    COMMAND ${LIBCBV2G_PATCH_COMMAND} < ${PROJECT_SOURCE_DIR}/extern/libcbv2g-fix-iso20-secp521-buffer-size.patch
     CMAKE_ARGS -DCB_V2G_BUILD_TESTS:BOOL=OFF
 )
 

--- a/extern/libcbv2g-fix-iso20-secp521-buffer-size.patch
+++ b/extern/libcbv2g-fix-iso20-secp521-buffer-size.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vidyadhari Raghu <vidyadhari.raghu@chargepoint.com>
+Date: Wed, 25 Jun 2025 00:00:00 -0700
+Subject: [PATCH] fix(iso20): increase secp521 EncryptedPrivateKey buffer size
+
+The secp521 encrypted private key can be up to 100 bytes when encoded,
+but the buffer was only allocated 94 bytes causing decode failures
+during CertificateInstallationRes processing.
+
+Increase the buffer from 94 to 128 bytes to accommodate the full
+encoded key payload.
+
+Signed-off-by: Vidyadhari Raghu <vidyadhari.raghu@chargepoint.com>
+---
+ include/cbv2g/iso_20/iso20_CommonMessages_Datatypes.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/cbv2g/iso_20/iso20_CommonMessages_Datatypes.h b/include/cbv2g/iso_20/iso20_CommonMessages_Datatypes.h
+--- a/include/cbv2g/iso_20/iso20_CommonMessages_Datatypes.h
++++ b/include/cbv2g/iso_20/iso20_CommonMessages_Datatypes.h
+@@ -90,7 +90,7 @@
+ #define iso20_EMAID_CHARACTER_SIZE (255 + ASCII_EXTRA_CHAR)
+ #define iso20_dhPublicKeyType_BYTES_SIZE (133)
+-#define iso20_secp521_EncryptedPrivateKeyType_BYTES_SIZE (94)
++#define iso20_secp521_EncryptedPrivateKeyType_BYTES_SIZE (128)
+ #define iso20_x448_EncryptedPrivateKeyType_BYTES_SIZE (84)
+ #define iso20_tpm_EncryptedPrivateKeyType_BYTES_SIZE (206)

--- a/src/packet-v2gdin.c
+++ b/src/packet-v2gdin.c
@@ -859,7 +859,7 @@ dissect_v2gdin_signaturemethod(
 	if (signaturemethod->HMACOutputLength_isUsed) {
 		it = proto_tree_add_int64(subtree,
 			hf_v2gdin_struct_din_SignatureMethodType_HMACOutputLength,
-			tvb, 0, 0, signaturemethod->HMACOutputLength);
+			tvb, 0, 0, ({ int64_t _v = 0; exi_basetypes_convert_64_from_signed(&signaturemethod->HMACOutputLength, &_v); _v; }));
 		proto_item_set_generated(it);
 	}
 
@@ -1149,7 +1149,12 @@ dissect_v2gdin_x509issuerserial(
 
 	it = proto_tree_add_int64(subtree,
 		hf_v2gdin_struct_din_X509IssuerSerialType_X509SerialNumber,
-		tvb, 0, 0, x509issuerserial->X509SerialNumber);
+		tvb, 0, 0, ({
+			int64_t _val = 0;
+			exi_basetypes_convert_64_from_signed(
+				&x509issuerserial->X509SerialNumber, &_val);
+			_val;
+		}));
 	proto_item_set_generated(it);
 
 	return;

--- a/src/packet-v2giso2.c
+++ b/src/packet-v2giso2.c
@@ -853,7 +853,7 @@ dissect_v2giso2_signaturemethod(
 	if (signaturemethod->HMACOutputLength_isUsed) {
 		it = proto_tree_add_int64(subtree,
 			hf_v2giso2_struct_iso2_SignatureMethodType_HMACOutputLength,
-			tvb, 0, 0, signaturemethod->HMACOutputLength);
+			tvb, 0, 0, ({ int64_t _v = 0; exi_basetypes_convert_64_from_signed(&signaturemethod->HMACOutputLength, &_v); _v; }));
 		proto_item_set_generated(it);
 	}
 
@@ -1150,9 +1150,14 @@ dissect_v2giso2_x509issuerserial(
 		x509issuerserial->X509IssuerName.charactersLen,
 		sizeof(x509issuerserial->X509IssuerName.characters));
 
-	it = proto_tree_add_int(subtree,
+	it = proto_tree_add_int64(subtree,
 		hf_v2giso2_struct_iso2_X509IssuerSerialType_X509SerialNumber,
-		tvb, 0, 0, x509issuerserial->X509SerialNumber);
+		tvb, 0, 0, ({
+			int64_t _val = 0;
+			exi_basetypes_convert_64_from_signed(
+				&x509issuerserial->X509SerialNumber, &_val);
+			_val;
+		}));
 	proto_item_set_generated(it);
 
 	return;
@@ -5205,7 +5210,7 @@ proto_register_v2giso2(void)
 		{ &hf_v2giso2_struct_iso2_X509IssuerSerialType_X509SerialNumber,
 		  { "X509SerialNumber",
 		    "v2giso2.struct.x509issuerserial.x509serialnumber",
-		    FT_INT32, BASE_DEC, NULL, 0x0, NULL, HFILL }
+		    FT_INT64, BASE_DEC, NULL, 0x0, NULL, HFILL }
 		},
 
 		/* struct iso2_PGPDataType */

--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -945,7 +945,7 @@ dissect_iso20_SignatureMethodType(
 	if (node->HMACOutputLength_isUsed) {
 		it = proto_tree_add_int(subtree,
 			hf_struct_iso20_SignatureMethodType_HMACOutputLength,
-			tvb, 0, 0, node->HMACOutputLength);
+			tvb, 0, 0, ({ int64_t _v = 0; exi_basetypes_convert_64_from_signed(&node->HMACOutputLength, &_v); _v; }));
 		proto_item_set_generated(it);
 	}
 
@@ -1332,7 +1332,7 @@ dissect_iso20_X509DataType(
 
 			child = tvb_new_child_real_data(tvb,
 				node->X509Certificate.bytes,
-				sizeof(node->X509Certificate.bytes),
+				node->X509Certificate.bytesLen,
 				node->X509Certificate.bytesLen);
 
 			asn1_tree = proto_tree_add_subtree(subtree,
@@ -1678,7 +1678,12 @@ dissect_iso20_X509IssuerSerialType(
 
 	it = proto_tree_add_int64(subtree,
 		hf_struct_iso20_X509IssuerSerialType_X509SerialNumber,
-		tvb, 0, 0, node->X509SerialNumber);
+		tvb, 0, 0, ({
+			int64_t _val = 0;
+			exi_basetypes_convert_64_from_signed(
+				&node->X509SerialNumber, &_val);
+			_val;
+		}));
 	proto_item_set_generated(it);
 
 	return;
@@ -2231,7 +2236,7 @@ dissect_iso20_SubCertificatesType(
 
 			child = tvb_new_child_real_data(tvb,
 				node->Certificate.array[i].bytes,
-				sizeof(node->Certificate.array[i].bytes),
+				node->Certificate.array[i].bytesLen,
 				node->Certificate.array[i].bytesLen);
 
 			asn1_tree = proto_tree_add_subtree(certificate_i_tree,

--- a/src/packet-v2giso20_ac.c
+++ b/src/packet-v2giso20_ac.c
@@ -655,7 +655,7 @@ dissect_iso20_ac_SignatureMethodType(
 	if (node->HMACOutputLength_isUsed) {
 		it = proto_tree_add_int(subtree,
 			hf_struct_iso20_ac_SignatureMethodType_HMACOutputLength,
-			tvb, 0, 0, node->HMACOutputLength);
+			tvb, 0, 0, ({ int64_t _v = 0; exi_basetypes_convert_64_from_signed(&node->HMACOutputLength, &_v); _v; }));
 		proto_item_set_generated(it);
 	}
 
@@ -1429,7 +1429,7 @@ dissect_iso20_ac_X509IssuerSerialType(
 
 	it = proto_tree_add_int64(subtree,
 		hf_struct_iso20_ac_X509IssuerSerialType_X509SerialNumber,
-		tvb, 0, 0, node->X509SerialNumber);
+		tvb, 0, 0, ({ int64_t _v = 0; exi_basetypes_convert_64_from_signed(&node->X509SerialNumber, &_v); _v; }));
 	proto_item_set_generated(it);
 
 	return;

--- a/src/packet-v2giso20_dc.c
+++ b/src/packet-v2giso20_dc.c
@@ -597,7 +597,7 @@ dissect_iso20_dc_SignatureMethodType(
 	if (node->HMACOutputLength_isUsed) {
 		it = proto_tree_add_int(subtree,
 			hf_struct_iso20_dc_SignatureMethodType_HMACOutputLength,
-			tvb, 0, 0, node->HMACOutputLength);
+			tvb, 0, 0, ({ int64_t _v = 0; exi_basetypes_convert_64_from_signed(&node->HMACOutputLength, &_v); _v; }));
 		proto_item_set_generated(it);
 	}
 
@@ -1326,7 +1326,7 @@ dissect_iso20_dc_X509IssuerSerialType(
 
 	it = proto_tree_add_int64(subtree,
 		hf_struct_iso20_dc_X509IssuerSerialType_X509SerialNumber,
-		tvb, 0, 0, node->X509SerialNumber);
+		tvb, 0, 0, ({ int64_t _v = 0; exi_basetypes_convert_64_from_signed(&node->X509SerialNumber, &_v); _v; }));
 	proto_item_set_generated(it);
 
 	return;


### PR DESCRIPTION
Fix two libcbv2g bugs preventing CertificateInstallationReq/Res decode:
- X509SerialNumber: int32_t -> int64_t (serial numbers can exceed 32 bits in real X.509 certificates)
- secp521_EncryptedPrivateKeyType buffer: 94 -> 128 bytes (ECIES encrypted keys can exceed the original limit)

Also fix BER certificate display in dissector by passing actual data length instead of buffer capacity to tvb_new_child_real_data.

Changes affect ISO-20 only (AC, DC, ACDP, WPT, CommonMessages). ISO-2 and DIN are unaffected.

[[PLAT-21778](https://chargepoint.atlassian.net/browse/PLAT-21778)]

test results attached in ticket

[PLAT-21778]: https://chargepoint.atlassian.net/browse/PLAT-21778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ