### PR TITLE
fix(v2g): enum names for iso20 pricing

### DIFF
--- a/src/packet-v2giso20.c
+++ b/src/packet-v2giso20.c
@@ -574,8 +574,8 @@ static const value_string v2giso20_param_mobilityneedsmode_names[] = {
 
 static const value_string v2giso20_param_pricing_names[] = {
 	{ 0, "NO_PRICING" },
-	{ 1, "STATIC" },
-	{ 2, "DYNAMIC" },
+	{ 1, "ABSOLUTE_PRICING" },
+	{ 2, "PRICE_LEVELS" },
 	{ 0, NULL }
 };
 


### PR DESCRIPTION
Corrected Pricing value from
"STATIC" to "ABOSULTE_PRICING"
"DYNAMIC" to "PRICE_LEVELS"

[[PLAT-22040](https://chargepoint.atlassian.net/browse/PLAT-22040)]

Test 

<img width="617" height="359" alt="Screenshot from 2026-08-06 12-47-32" src="https://github.com/user-attachments/assets/e41257bb-f9a6-45ae-a2eb-3bc8f6704377" />


[PLAT-22040]: https://chargepoint.atlassian.net/browse/PLAT-22040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ